### PR TITLE
Add macOS camera controls

### DIFF
--- a/SampleApp/Scene/CameraController.swift
+++ b/SampleApp/Scene/CameraController.swift
@@ -1,0 +1,29 @@
+#if os(macOS)
+import simd
+
+final class CameraController: ObservableObject {
+    @Published var yaw: Float = 0
+    @Published var pitch: Float = 0
+    @Published var distance: Float = -Constants.modelCenterZ
+
+    private let minDistance: Float = 1
+    private let maxDistance: Float = 50
+    private let pitchLimit: Float = .pi / 2 - 0.01
+
+    func rotate(deltaX: Float, deltaY: Float) {
+        yaw += deltaX
+        pitch = max(-pitchLimit, min(pitchLimit, pitch + deltaY))
+    }
+
+    func zoom(delta: Float) {
+        distance = max(minDistance, min(maxDistance, distance - delta))
+    }
+
+    var viewMatrix: simd_float4x4 {
+        let translation = matrix4x4_translation(0, 0, -distance)
+        let pitchMatrix = matrix4x4_rotation(radians: pitch, axis: SIMD3<Float>(1, 0, 0))
+        let yawMatrix = matrix4x4_rotation(radians: yaw, axis: SIMD3<Float>(0, 1, 0))
+        return translation * pitchMatrix * yawMatrix
+    }
+}
+#endif

--- a/SampleApp/Scene/InteractiveMTKView.swift
+++ b/SampleApp/Scene/InteractiveMTKView.swift
@@ -1,0 +1,27 @@
+#if os(macOS)
+import MetalKit
+
+final class InteractiveMTKView: MTKView {
+    var cameraController: CameraController?
+    private var lastDrag: CGPoint?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        lastDrag = event.locationInWindow
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let last = lastDrag else { return }
+        let location = event.locationInWindow
+        let dx = Float(location.x - last.x)
+        let dy = Float(location.y - last.y)
+        cameraController?.rotate(deltaX: dx * 0.005, deltaY: dy * 0.005)
+        lastDrag = location
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        cameraController?.zoom(delta: Float(event.scrollingDeltaY) * 0.1)
+    }
+}
+#endif

--- a/SampleApp/Scene/MetalKitSceneView.swift
+++ b/SampleApp/Scene/MetalKitSceneView.swift
@@ -14,6 +14,9 @@ struct MetalKitSceneView: ViewRepresentable {
 
     class Coordinator {
         var renderer: MetalKitSceneRenderer?
+#if os(macOS)
+        let camera = CameraController()
+#endif
     }
 
     func makeCoordinator() -> Coordinator {
@@ -31,13 +34,22 @@ struct MetalKitSceneView: ViewRepresentable {
 #endif
 
     private func makeView(_ coordinator: Coordinator) -> MTKView {
+#if os(macOS)
+        let metalKitView = InteractiveMTKView()
+        metalKitView.cameraController = coordinator.camera
+#else
         let metalKitView = MTKView()
+#endif
 
         if let metalDevice = MTLCreateSystemDefaultDevice() {
             metalKitView.device = metalDevice
         }
 
-        let renderer = MetalKitSceneRenderer(metalKitView)
+        let renderer = MetalKitSceneRenderer(metalKitView
+#if os(macOS)
+                                              , camera: coordinator.camera
+#endif
+        )
         coordinator.renderer = renderer
         metalKitView.delegate = renderer
 


### PR DESCRIPTION
## Summary
- add `CameraController` and `InteractiveMTKView` for macOS
- hook interactive camera into `MetalKitSceneView`
- update `MetalKitSceneRenderer` to support optional camera controller

## Testing
- `swift test -l` *(fails: no such module 'os' / 'Metal')*

------
https://chatgpt.com/codex/tasks/task_e_68838221751c8321a0a9a707d091e98b