### PR TITLE
Introduce interaction state helper for visionOS renderer

### DIFF
--- a/SampleApp/App/Constants.swift
+++ b/SampleApp/App/Constants.swift
@@ -3,7 +3,9 @@ import SwiftUI
 
 enum Constants {
     static let maxSimultaneousRenders = 3
+#if !os(visionOS)
     static let rotationPerSecond = Angle(degrees: 7)
+#endif
     static let rotationAxis = SIMD3<Float>(0, 1, 0)
 #if !os(visionOS)
     static let fovy = Angle(degrees: 65)

--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */; };
 		61791E132B416DD700302B57 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E112B416DCF00302B57 /* Constants.swift */; };
 		61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
+		61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */; };
 		617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
 		617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
 /* End PBXBuildFile section */
@@ -45,6 +46,7 @@
 		61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneRenderer.swift; sourceTree = "<group>"; };
 		61791E112B416DCF00302B57 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		61791E142B42294700302B57 /* MetalKitSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneView.swift; sourceTree = "<group>"; };
+		61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneInteractionState.swift; sourceTree = "<group>"; };
 		617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -81,10 +83,11 @@
 				147AFBCF2E33ED730052B2AD /* InteractiveMTKView.swift */,
 				610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */,
 				61791DF72B41551F00302B57 /* ContentView.swift */,
-				61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
-				61791E142B42294700302B57 /* MetalKitSceneView.swift */,
-				61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
-			);
+                                61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
+                		61791E142B42294700302B57 /* MetalKitSceneView.swift */,
+                                61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
+                		61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */,
+                        );
 			path = Scene;
 			sourceTree = "<group>";
 		};
@@ -220,8 +223,9 @@
 				61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */,
 				61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */,
 				147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */,
-				147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
-				61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
+                                147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
+                		61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */,
+                                61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
 				61791DCF2B41544300302B57 /* Assets.xcassets in Sources */,
 				61791E132B416DD700302B57 /* Constants.swift in Sources */,
 				61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */,

--- a/SampleApp/Scene/SceneInteractionState.swift
+++ b/SampleApp/Scene/SceneInteractionState.swift
@@ -1,0 +1,72 @@
+#if os(visionOS)
+
+import os
+import simd
+
+final class SceneInteractionState {
+    struct Values {
+        var translation: SIMD3<Float> = .zero
+        var rotation: simd_quatf = simd_quatf()
+        var scale: Float = 1.0
+    }
+
+    private let scaleRange: ClosedRange<Float>
+    private let lock: OSAllocatedUnfairLock<Values>
+
+    init(scaleRange: ClosedRange<Float> = 0.2...5.0) {
+        self.scaleRange = scaleRange
+        let initialState = Values()
+        self.lock = OSAllocatedUnfairLock(initialState: initialState)
+        assert(SceneInteractionState.isApproximatelyIdentity(SceneInteractionState.matrix(for: initialState)))
+    }
+
+    func currentMatrix() -> simd_float4x4 {
+        return lock.withLock { values in
+            SceneInteractionState.matrix(for: values)
+        }
+    }
+
+    func update(_ body: (inout Values) -> Void) {
+        lock.withLock { values in
+            body(&values)
+            values.rotation = values.rotation.normalized
+            values.scale = SceneInteractionState.clamp(values.scale, to: scaleRange)
+            assert(scaleRange.contains(values.scale))
+        }
+    }
+}
+
+private extension SceneInteractionState {
+    static func clamp(_ value: Float, to range: ClosedRange<Float>) -> Float {
+        return min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    static func matrix(for values: Values) -> simd_float4x4 {
+        let translationMatrix = matrix4x4_translation(values.translation.x,
+                                                      values.translation.y,
+                                                      values.translation.z)
+        let rotationMatrix = simd_float4x4(values.rotation.normalized)
+        let scaleVector = SIMD4<Float>(values.scale, values.scale, values.scale, 1)
+        let scaleMatrix = simd_float4x4(diagonal: scaleVector)
+        return translationMatrix * rotationMatrix * scaleMatrix
+    }
+
+    static func isApproximatelyIdentity(_ matrix: simd_float4x4, epsilon: Float = 1e-5) -> Bool {
+        var isIdentity = true
+        for row in 0..<4 {
+            for column in 0..<4 {
+                let expected: Float = row == column ? 1 : 0
+                if abs(matrix[row][column] - expected) > epsilon {
+                    isIdentity = false
+                    break
+                }
+            }
+            if !isIdentity {
+                break
+            }
+        }
+        return isIdentity
+    }
+}
+
+#endif // os(visionOS)

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -29,9 +29,7 @@ class VisionSceneRenderer {
     var modelRenderer: (any ModelRenderer)?
 
     let inFlightSemaphore = DispatchSemaphore(value: Constants.maxSimultaneousRenders)
-
-    var lastRotationUpdateTimestamp: Date? = nil
-    var rotation: Angle = .zero
+    let interactionState = SceneInteractionState()
 
     let arSession: ARKitSession
     let worldTracking: WorldTrackingProvider
@@ -43,6 +41,9 @@ class VisionSceneRenderer {
 
         worldTracking = WorldTrackingProvider()
         arSession = ARKitSession()
+        interactionState.update { values in
+            values.translation = SIMD3<Float>(0.0, 0.0, Constants.modelCenterZ)
+        }
     }
 
     func load(_ model: ModelIdentifier?) async throws {
@@ -89,9 +90,6 @@ class VisionSceneRenderer {
     }
 
     private func viewports(drawable: LayerRenderer.Drawable, deviceAnchor: DeviceAnchor?) -> [ModelRendererViewportDescriptor] {
-        let rotationMatrix = matrix4x4_rotation(radians: Float(rotation.radians),
-                                                axis: Constants.rotationAxis)
-        let translationMatrix = matrix4x4_translation(0.0, 0.0, Constants.modelCenterZ)
         // Turn common 3D GS PLY files rightside-up. This isn't generally meaningful, it just
         // happens to be a useful default for the most common datasets at the moment.
         let commonUpCalibration = matrix4x4_rotation(radians: .pi, axis: SIMD3<Float>(0, 0, 1))
@@ -126,19 +124,9 @@ class VisionSceneRenderer {
                                    y: Int(view.textureMap.viewport.height))
             return ModelRendererViewportDescriptor(viewport: view.textureMap.viewport,
                                                    projectionMatrix: projMatrixSIMD,
-                                                   viewMatrix: userViewpointMatrix * translationMatrix * rotationMatrix * commonUpCalibration,
+                                                   viewMatrix: userViewpointMatrix * interactionState.currentMatrix() * commonUpCalibration,
                                                    screenSize: screenSize)
         }
-    }
-
-    private func updateRotation() {
-        let now = Date()
-        defer {
-            lastRotationUpdateTimestamp = now
-        }
-
-        guard let lastRotationUpdateTimestamp else { return }
-        rotation += Constants.rotationPerSecond * now.timeIntervalSince(lastRotationUpdateTimestamp)
     }
 
     func renderFrame() {
@@ -169,8 +157,6 @@ class VisionSceneRenderer {
         commandBuffer.addCompletedHandler { (_ commandBuffer)-> Swift.Void in
             semaphore.signal()
         }
-
-        updateRotation()
 
         let viewports = self.viewports(drawable: drawable, deviceAnchor: deviceAnchor)
 


### PR DESCRIPTION
## Summary
- add a locked SceneInteractionState helper for visionOS that tracks translation, rotation, and scale
- update VisionSceneRenderer to use the shared interaction state matrix instead of time-based rotation
- guard the rotation-per-second constant on non-visionOS builds and register the new helper in the Xcode project

## Testing
- swift test *(fails: SampleBoxRenderer.swift:1:8: error: no such module 'Metal'; linux environment lacks Apple frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0a63b8b08321bc4a027924604744