### PR TITLE
Add two-hand hand-tracking gesture support

### DIFF
--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -23,8 +23,9 @@
 		61791E022B415D3F00302B57 /* SampleBoxRenderer in Frameworks */ = {isa = PBXBuildFile; productRef = 61791E012B415D3F00302B57 /* SampleBoxRenderer */; };
 		61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */; };
 		61791E132B416DD700302B57 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E112B416DCF00302B57 /* Constants.swift */; };
-		61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
-		61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */; };
+                61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
+                61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */; };
+                61F9C1A62C12345600AAA112 /* TwoHandGestureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9C1A52C12345600AAA112 /* TwoHandGestureController.swift */; };
 		617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
 		617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
 /* End PBXBuildFile section */
@@ -45,8 +46,9 @@
 		61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisionSceneRenderer.swift; sourceTree = "<group>"; };
 		61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneRenderer.swift; sourceTree = "<group>"; };
 		61791E112B416DCF00302B57 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		61791E142B42294700302B57 /* MetalKitSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneView.swift; sourceTree = "<group>"; };
-		61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneInteractionState.swift; sourceTree = "<group>"; };
+                61791E142B42294700302B57 /* MetalKitSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneView.swift; sourceTree = "<group>"; };
+                61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneInteractionState.swift; sourceTree = "<group>"; };
+                61F9C1A52C12345600AAA112 /* TwoHandGestureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoHandGestureController.swift; sourceTree = "<group>"; };
 		617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -84,9 +86,10 @@
 				610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */,
 				61791DF72B41551F00302B57 /* ContentView.swift */,
                                 61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
-                		61791E142B42294700302B57 /* MetalKitSceneView.swift */,
+                                61791E142B42294700302B57 /* MetalKitSceneView.swift */,
                                 61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
-                		61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */,
+                                61F9C1A22C12345600AAA111 /* SceneInteractionState.swift */,
+                                61F9C1A52C12345600AAA112 /* TwoHandGestureController.swift */,
                         );
 			path = Scene;
 			sourceTree = "<group>";
@@ -224,7 +227,8 @@
 				61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */,
 				147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */,
                                 147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
-                		61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */,
+                                61F9C1A42C12345600AAA111 /* SceneInteractionState.swift in Sources */,
+                                61F9C1A62C12345600AAA112 /* TwoHandGestureController.swift in Sources */,
                                 61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
 				61791DCF2B41544300302B57 /* Assets.xcassets in Sources */,
 				61791E132B416DD700302B57 /* Constants.swift in Sources */,

--- a/SampleApp/Scene/SceneInteractionState.swift
+++ b/SampleApp/Scene/SceneInteractionState.swift
@@ -10,6 +10,18 @@ final class SceneInteractionState {
         var scale: Float = 1.0
     }
 
+    struct Update {
+        var translation: SIMD3<Float>
+        var rotation: simd_quatf
+        var scale: Float
+
+        init(translation: SIMD3<Float>, rotation: simd_quatf, scale: Float) {
+            self.translation = translation
+            self.rotation = rotation
+            self.scale = scale
+        }
+    }
+
     private let scaleRange: ClosedRange<Float>
     private let lock: OSAllocatedUnfairLock<Values>
 
@@ -31,6 +43,15 @@ final class SceneInteractionState {
             body(&values)
             values.rotation = values.rotation.normalized
             values.scale = SceneInteractionState.clamp(values.scale, to: scaleRange)
+            assert(scaleRange.contains(values.scale))
+        }
+    }
+
+    func update(_ update: Update) {
+        lock.withLock { values in
+            values.translation = update.translation
+            values.rotation = update.rotation.normalized
+            values.scale = SceneInteractionState.clamp(update.scale, to: scaleRange)
             assert(scaleRange.contains(values.scale))
         }
     }

--- a/SampleApp/Scene/TwoHandGestureController.swift
+++ b/SampleApp/Scene/TwoHandGestureController.swift
@@ -1,0 +1,194 @@
+#if os(visionOS)
+
+import ARKit
+import os
+import simd
+
+final class TwoHandGestureController {
+    enum Phase {
+        case idle
+        case began
+        case changed
+    }
+
+    private struct State {
+        var phase: Phase = .idle
+        var initialMidpoint: SIMD3<Float> = .zero
+        var initialSeparation: Float = 0
+        var initialOrientation: simd_quatf = simd_quatf()
+    }
+
+    private let interactionState: SceneInteractionState
+    private let log: Logger
+    private let stateLock: OSAllocatedUnfairLock<State>
+
+    init(interactionState: SceneInteractionState, log: Logger) {
+        self.interactionState = interactionState
+        self.log = log
+        self.stateLock = OSAllocatedUnfairLock(initialState: State())
+    }
+
+    func handleTwoHandPinch(_ pinch: SpatialEventCollection.TwoHandPinch) {
+        guard let sample = Sample(pinch: pinch) else {
+            endGestureIfNeeded(reason: "invalidPinchSample")
+            return
+        }
+
+        let pinchPhase = pinch.gesturePhase
+        switch pinchPhase {
+        case .began:
+            begin(sample: sample)
+        case .changed:
+            update(sample: sample)
+        case .ended, .cancelled:
+            endGestureIfNeeded(reason: "phaseEnded")
+        @unknown default:
+            endGestureIfNeeded(reason: "unknownPhase")
+        }
+    }
+
+    func updateFromAnchors(_ anchors: HandTrackingProvider.HandAnchors) {
+        guard let left = anchors.left,
+              let right = anchors.right else {
+            endGestureIfNeeded(reason: "missingAnchors")
+            return
+        }
+
+        guard left.isPinching && right.isPinching,
+              let sample = Sample(left: left.originFromAnchorTransform,
+                                   right: right.originFromAnchorTransform) else {
+            endGestureIfNeeded(reason: "noPinchDetected")
+            return
+        }
+
+        stateLock.withLock { state in
+            switch state.phase {
+            case .idle:
+                state.phase = .began
+                state.initialMidpoint = sample.midpoint
+                state.initialSeparation = sample.separation
+                state.initialOrientation = sample.orientation
+                log.debug("Two-hand pinch began (fallback)")
+                let resetUpdate = SceneInteractionState.Update(translation: .zero,
+                                                               rotation: simd_quatf(),
+                                                               scale: 1.0)
+                interactionState.update(resetUpdate)
+            case .began, .changed:
+                state.phase = .changed
+                let update = makeUpdate(for: sample, state: state)
+                interactionState.update(update)
+            }
+        }
+    }
+}
+
+private extension TwoHandGestureController {
+    struct Sample {
+        let midpoint: SIMD3<Float>
+        let separation: Float
+        let orientation: simd_quatf
+
+        init?(pinch: SpatialEventCollection.TwoHandPinch) {
+            guard let left = pinch.leftHand?.originFromAnchorTransform,
+                  let right = pinch.rightHand?.originFromAnchorTransform else {
+                return nil
+            }
+            self.init(left: left, right: right)
+        }
+
+        init?(left: simd_float4x4, right: simd_float4x4) {
+            let leftPosition = left.translation
+            let rightPosition = right.translation
+            let vector = rightPosition - leftPosition
+            let distance = simd_length(vector)
+            if distance.isZero {
+                return nil
+            }
+
+            midpoint = (leftPosition + rightPosition) * 0.5
+            separation = distance
+            orientation = TwoHandGestureController.orientation(for: leftPosition, right: rightPosition)
+        }
+    }
+
+    func begin(sample: Sample) {
+        stateLock.withLock { state in
+            state.phase = .began
+            state.initialMidpoint = sample.midpoint
+            state.initialSeparation = sample.separation
+            state.initialOrientation = sample.orientation
+            log.debug("Two-hand pinch began")
+            let resetUpdate = SceneInteractionState.Update(translation: .zero,
+                                                           rotation: simd_quatf(),
+                                                           scale: 1.0)
+            interactionState.update(resetUpdate)
+        }
+    }
+
+    func update(sample: Sample) {
+        stateLock.withLock { state in
+            guard state.phase != .idle else {
+                state.phase = .began
+                state.initialMidpoint = sample.midpoint
+                state.initialSeparation = sample.separation
+                state.initialOrientation = sample.orientation
+                log.debug("Two-hand pinch began implicitly")
+                let resetUpdate = SceneInteractionState.Update(translation: .zero,
+                                                               rotation: simd_quatf(),
+                                                               scale: 1.0)
+                interactionState.update(resetUpdate)
+                return
+            }
+
+            state.phase = .changed
+            let update = makeUpdate(for: sample, state: state)
+            interactionState.update(update)
+        }
+    }
+
+    func endGestureIfNeeded(reason: StaticString) {
+        stateLock.withLock { state in
+            guard state.phase != .idle else { return }
+            log.debug("Two-hand pinch ended: \(String(describing: reason))")
+            state.phase = .idle
+            state.initialMidpoint = .zero
+            state.initialSeparation = 0
+            state.initialOrientation = simd_quatf()
+        }
+    }
+
+    func makeUpdate(for sample: Sample, state: State) -> SceneInteractionState.Update {
+        let translation = sample.midpoint - state.initialMidpoint
+        let scaleRatio = max(sample.separation / max(state.initialSeparation, 0.001), 0.01)
+        let rotationDelta = sample.orientation * state.initialOrientation.inverse
+        return SceneInteractionState.Update(translation: translation,
+                                            rotation: rotationDelta.normalized,
+                                            scale: scaleRatio)
+    }
+}
+
+private extension simd_float4x4 {
+    var translation: SIMD3<Float> {
+        SIMD3<Float>(columns.3.x, columns.3.y, columns.3.z)
+    }
+}
+
+private extension TwoHandGestureController {
+    static func orientation(for left: SIMD3<Float>, right: SIMD3<Float>) -> simd_quatf {
+        let forward = normalize(right - left)
+        let reference = SIMD3<Float>(0, 0, -1)
+        let axis = simd_cross(reference, forward)
+        let axisLength = simd_length(axis)
+        if axisLength < 1e-5 {
+            if simd_dot(reference, forward) > 0.0 {
+                return simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
+            } else {
+                return simd_quatf(angle: .pi, axis: SIMD3<Float>(0, 1, 0))
+            }
+        }
+        let angle = acos(simd_dot(reference, forward))
+        return simd_quatf(angle: angle, axis: axis / axisLength)
+    }
+}
+
+#endif // os(visionOS)

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -1,5 +1,6 @@
 #if os(visionOS)
 
+import ARKit
 import CompositorServices
 import Metal
 import MetalSplatter
@@ -33,6 +34,10 @@ class VisionSceneRenderer {
 
     let arSession: ARKitSession
     let worldTracking: WorldTrackingProvider
+    let handTracking: HandTrackingProvider
+
+    private lazy var twoHandGestureController = TwoHandGestureController(interactionState: interactionState,
+                                                                         log: Self.log)
 
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
@@ -40,6 +45,7 @@ class VisionSceneRenderer {
         self.commandQueue = self.device.makeCommandQueue()!
 
         worldTracking = WorldTrackingProvider()
+        handTracking = HandTrackingProvider()
         arSession = ARKitSession()
         interactionState.update { values in
             values.translation = SIMD3<Float>(0.0, 0.0, Constants.modelCenterZ)
@@ -75,10 +81,44 @@ class VisionSceneRenderer {
 
     func startRenderLoop() {
         Task {
+            var providers: [any DataProvider] = [worldTracking]
+
+            if HandTrackingProvider.isSupported {
+                do {
+                    let status = try await handTracking.requestAuthorization()
+                    switch status {
+                    case .authorized, .notDetermined:
+                        providers.append(handTracking)
+                        Self.log.debug("Hand tracking authorized")
+                    case .denied, .restricted:
+                        Self.log.warning("Hand tracking authorization denied")
+                    @unknown default:
+                        Self.log.error("Unexpected hand tracking authorization status")
+                    }
+                } catch {
+                    Self.log.error("Hand tracking authorization failed: \(error.localizedDescription)")
+                }
+            } else {
+                Self.log.info("Hand tracking not supported on this device")
+            }
+
             do {
-                try await arSession.run([worldTracking])
+                try await arSession.run(providers)
             } catch {
-                fatalError("Failed to initialize ARSession")
+                if providers.contains(where: { $0 is HandTrackingProvider }) {
+                    Self.log.error("ARSession failed to start with hand tracking: \(error.localizedDescription)")
+                    do {
+                        try await arSession.run([worldTracking])
+                    } catch {
+                        fatalError("Failed to initialize ARSession")
+                    }
+                } else {
+                    fatalError("Failed to initialize ARSession")
+                }
+            }
+
+            Task { [weak self] in
+                await self?.eventLoop()
             }
 
             let renderThread = Thread {
@@ -87,6 +127,31 @@ class VisionSceneRenderer {
             renderThread.name = "Render Thread"
             renderThread.start()
         }
+    }
+
+    private func eventLoop() async {
+        for await event in layerRenderer.eventQueue {
+            guard case .spatial(let collection) = event else { continue }
+            if !processTwoHandPinchEvents(collection) {
+                processFallbackPinch()
+            }
+        }
+    }
+
+    @discardableResult
+    private func processTwoHandPinchEvents(_ collection: SpatialEventCollection) -> Bool {
+        var handled = false
+        for pinch in collection.twoHandPinch {
+            handled = true
+            twoHandGestureController.handleTwoHandPinch(pinch)
+        }
+        return handled
+    }
+
+    private func processFallbackPinch() {
+        guard HandTrackingProvider.isSupported else { return }
+        let anchors = handTracking.handAnchors
+        twoHandGestureController.updateFromAnchors(anchors)
     }
 
     private func viewports(drawable: LayerRenderer.Drawable, deviceAnchor: DeviceAnchor?) -> [ModelRendererViewportDescriptor] {


### PR DESCRIPTION
## Summary
- integrate the hand tracking provider into the VisionSceneRenderer render loop and fall back cleanly when unsupported
- consume spatial event queue updates to drive a new two-hand gesture controller that maps pinch input to scene interaction updates
- add SceneInteractionState conveniences and project wiring for the helper, including logging for gesture transitions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fd0ea3d5188321b2bfacd0948b3375