### PR TITLE
Implement PBR shading and relighting pipeline

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -2,7 +2,10 @@
 
 typedef struct
 {
-    half4 color [[raster_order_group(0)]];
+    half4 albedoMetallic [[raster_order_group(0)]];
+    half4 normalRoughness [[raster_order_group(0)]];
+    half4 viewAlpha [[raster_order_group(0)]];
+    half2 ambientOcclusion [[raster_order_group(0)]];
     float depth [[raster_order_group(0)]];
 } FragmentValues;
 
@@ -20,7 +23,10 @@ typedef struct
 kernel void initializeFragmentStore(imageblock<FragmentValues, imageblock_layout_explicit> blockData,
                                     ushort2 localThreadID [[thread_position_in_threadgroup]]) {
     threadgroup_imageblock FragmentValues *values = blockData.data(localThreadID);
-    values->color = { 0, 0, 0, 0 };
+    values->albedoMetallic = half4(0);
+    values->normalRoughness = half4(0);
+    values->viewAlpha = half4(0);
+    values->ambientOcclusion = half2(0);
     values->depth = 0;
 }
 
@@ -41,6 +47,8 @@ vertex FragmentIn multiStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.metallic = half(0);
         out.roughness = half(0);
         out.normal = half3(0);
+        out.worldPosition = float3(0);
+        out.viewDirection = float3(0);
         return out;
     }
 
@@ -54,16 +62,26 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
     FragmentStore out;
 
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a);
-    half4 colorWithPremultipliedAlpha = half4(in.color.rgb * alpha, alpha);
+    if (alpha <= 0) {
+        out.values = previousFragmentValues;
+        return out;
+    }
 
     half oneMinusAlpha = 1 - alpha;
+    half ao = computeAmbientOcclusion(in.color.a);
 
-    half4 previousColor = previousFragmentValues.color;
-    out.values.color = previousColor * oneMinusAlpha + colorWithPremultipliedAlpha;
+    half4 albedoMetallic = half4(in.albedo * alpha, in.metallic * alpha);
+    half4 normalRoughness = half4(in.normal * alpha, in.roughness * alpha);
+    half4 viewAlpha = half4(half3(in.viewDirection) * alpha, alpha);
+    half2 ambientOcclusion = half2(ao * alpha, 0);
 
-    float previousDepth = previousFragmentValues.depth;
+    out.values.albedoMetallic = previousFragmentValues.albedoMetallic * oneMinusAlpha + albedoMetallic;
+    out.values.normalRoughness = previousFragmentValues.normalRoughness * oneMinusAlpha + normalRoughness;
+    out.values.viewAlpha = previousFragmentValues.viewAlpha * oneMinusAlpha + viewAlpha;
+    out.values.ambientOcclusion = previousFragmentValues.ambientOcclusion * oneMinusAlpha + ambientOcclusion;
+
     float depth = in.position.z;
-    out.values.depth = previousDepth * oneMinusAlpha + depth * alpha;
+    out.values.depth = previousFragmentValues.depth * oneMinusAlpha + depth * alpha;
 
     return out;
 }
@@ -84,16 +102,67 @@ vertex FragmentIn postprocessVertexShader(uint vertexID [[vertex_id]]) {
     out.metallic = half(0);
     out.roughness = half(0);
     out.normal = half3(0);
+    out.worldPosition = float3(0);
+    out.viewDirection = float3(0);
     return out;
 }
 
-fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[imageblock_data]]) {
+inline half4 resolveFragmentValues(FragmentValues fragmentValues,
+                                   texturecube<half> environmentMap,
+                                   texture2d<half> brdfLUT,
+                                   sampler environmentSampler,
+                                   sampler brdfSampler) {
+    half accumulatedAlpha = fragmentValues.viewAlpha.w;
+    if (accumulatedAlpha <= 0) {
+        return half4(0);
+    }
+
+    half invAlpha = half(1.0) / accumulatedAlpha;
+    half3 albedo = half3(fragmentValues.albedoMetallic.xyz * invAlpha);
+    half metallic = fragmentValues.albedoMetallic.w * invAlpha;
+    half3 normal = half3(fragmentValues.normalRoughness.xyz * invAlpha);
+    half roughness = fragmentValues.normalRoughness.w * invAlpha;
+    half3 viewDirection = half3(fragmentValues.viewAlpha.xyz * invAlpha);
+    half ao = fragmentValues.ambientOcclusion.x * invAlpha;
+
+    half3 shaded = shadeGaussian(albedo,
+                                 metallic,
+                                 roughness,
+                                 normal,
+                                 viewDirection,
+                                 ao,
+                                 environmentMap,
+                                 brdfLUT,
+                                 environmentSampler,
+                                 brdfSampler);
+
+    return half4(shaded * accumulatedAlpha, accumulatedAlpha);
+}
+
+fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[imageblock_data]],
+                                               texturecube<half> environmentMap [[texture(TextureIndexEnvironment)]],
+                                               texture2d<half> brdfLUT [[texture(TextureIndexBRDF)]],
+                                               sampler environmentSampler [[sampler(SamplerIndexEnvironment)]],
+                                               sampler brdfSampler [[sampler(SamplerIndexBRDF)]]) {
     FragmentOut out;
-    out.depth = (fragmentValues.color.a == 0) ? 0 : fragmentValues.depth / fragmentValues.color.a;
-    out.color = fragmentValues.color;
+    half accumulatedAlpha = fragmentValues.viewAlpha.w;
+    out.depth = (accumulatedAlpha == 0) ? 0 : fragmentValues.depth / accumulatedAlpha;
+    out.color = resolveFragmentValues(fragmentValues,
+                                      environmentMap,
+                                      brdfLUT,
+                                      environmentSampler,
+                                      brdfSampler);
     return out;
 }
 
-fragment half4 postprocessFragmentShaderNoDepth(FragmentValues fragmentValues [[imageblock_data]]) {
-    return fragmentValues.color;
+fragment half4 postprocessFragmentShaderNoDepth(FragmentValues fragmentValues [[imageblock_data]],
+                                               texturecube<half> environmentMap [[texture(TextureIndexEnvironment)]],
+                                               texture2d<half> brdfLUT [[texture(TextureIndexBRDF)]],
+                                               sampler environmentSampler [[sampler(SamplerIndexEnvironment)]],
+                                               sampler brdfSampler [[sampler(SamplerIndexBRDF)]]) {
+    return resolveFragmentValues(fragmentValues,
+                                 environmentMap,
+                                 brdfLUT,
+                                 environmentSampler,
+                                 brdfSampler);
 }

--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -30,6 +30,8 @@ typedef struct
     matrix_float4x4 projectionMatrix;
     matrix_float4x4 viewMatrix;
     uint2 screenSize;
+    uint2 _paddingScreen;
+    float4 cameraPosition;
 
     /*
      The first N splats are represented as as 2N primitives and 4N vertex indices. The remained are represented
@@ -38,6 +40,7 @@ typedef struct
      */
     uint splatCount;
     uint indexedSplatCount;
+    uint2 _paddingCounts;
 } Uniforms;
 
 typedef struct
@@ -55,6 +58,7 @@ typedef struct
     half          metallic;
     half          roughness;
     packed_half3 normal;
+    packed_half4 rotation;
 } Splat;
 
 typedef struct
@@ -66,4 +70,6 @@ typedef struct
     half metallic;
     half roughness;
     half3 normal;
+    float3 worldPosition;
+    float3 viewDirection;
 } FragmentIn;

--- a/MetalSplatter/Resources/SingleStageRenderPath.metal
+++ b/MetalSplatter/Resources/SingleStageRenderPath.metal
@@ -17,6 +17,8 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.metallic = half(0);
         out.roughness = half(0);
         out.normal = half3(0);
+        out.worldPosition = float3(0);
+        out.viewDirection = float3(0);
         return out;
     }
 
@@ -25,7 +27,27 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
     return splatVertex(splat, uniforms, vertexID % 4);
 }
 
-fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]]) {
+fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]],
+                                             texturecube<half> environmentMap [[texture(TextureIndexEnvironment)]],
+                                             texture2d<half> brdfLUT [[texture(TextureIndexBRDF)]],
+                                             sampler environmentSampler [[sampler(SamplerIndexEnvironment)]],
+                                             sampler brdfSampler [[sampler(SamplerIndexBRDF)]]) {
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a);
-    return half4(alpha * in.color.rgb, alpha);
+    if (alpha <= 0) {
+        return half4(0);
+    }
+
+    half ao = computeAmbientOcclusion(in.color.a);
+    half3 shaded = shadeGaussian(in.albedo,
+                                 in.metallic,
+                                 in.roughness,
+                                 in.normal,
+                                 half3(in.viewDirection),
+                                 ao,
+                                 environmentMap,
+                                 brdfLUT,
+                                 environmentSampler,
+                                 brdfSampler);
+
+    return half4(shaded * alpha, alpha);
 }

--- a/MetalSplatter/Resources/SplatProcessing.h
+++ b/MetalSplatter/Resources/SplatProcessing.h
@@ -14,3 +14,16 @@ FragmentIn splatVertex(Splat splat,
                        uint relativeVertexIndex);
 
 half splatFragmentAlpha(half2 relativePosition, half splatAlpha);
+
+half computeAmbientOcclusion(half opacity);
+
+half3 shadeGaussian(half3 albedo,
+                    half metallic,
+                    half roughness,
+                    half3 normal,
+                    half3 viewDirection,
+                    half ambientOcclusion,
+                    texturecube<half> environmentMap,
+                    texture2d<half> brdfLUT,
+                    sampler environmentSampler,
+                    sampler brdfSampler);

--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -1,5 +1,80 @@
 #import "SplatProcessing.h"
 
+float4 normalizeQuaternion(float4 quaternion) {
+    float lengthSquared = dot(quaternion, quaternion);
+    if (!isfinite(lengthSquared) || lengthSquared <= 0) {
+        return float4(0, 0, 0, 1);
+    }
+    float length = sqrt(lengthSquared);
+    return quaternion / length;
+}
+
+float3 rotateVectorByQuaternion(float4 quaternion, float3 vector) {
+    float4 normalizedQuaternion = normalizeQuaternion(quaternion);
+    float3 qVec = normalizedQuaternion.xyz;
+    float qW = normalizedQuaternion.w;
+    float3 t = 2.0 * cross(qVec, vector);
+    return vector + qW * t + cross(qVec, t);
+}
+
+float3 safeNormalize(float3 value, float3 fallback) {
+    float lengthSquared = dot(value, value);
+    if (!isfinite(lengthSquared) || lengthSquared <= 0) {
+        return fallback;
+    }
+    return normalize(value);
+}
+
+half computeAmbientOcclusion(half opacity) {
+    half clampedOpacity = clamp(opacity, half(0), half(1));
+    return half(1) - half(fast::exp(-float(clampedOpacity)));
+}
+
+float3 sampleDiffuseIrradiance(texturecube<half> environmentMap,
+                               sampler environmentSampler,
+                               float3 normal) {
+    uint mipCount = environmentMap.get_num_mip_levels();
+    uint diffuseMip = mipCount == 0 ? 0 : mipCount - 1;
+    return float3(environmentMap.sample(environmentSampler, normal, level(float(diffuseMip))).rgb);
+}
+
+half3 shadeGaussian(half3 albedo,
+                    half metallic,
+                    half roughness,
+                    half3 normal,
+                    half3 viewDirection,
+                    half ambientOcclusion,
+                    texturecube<half> environmentMap,
+                    texture2d<half> brdfLUT,
+                    sampler environmentSampler,
+                    sampler brdfSampler) {
+    float3 N = safeNormalize(float3(normal), float3(0, 0, 1));
+    float3 V = safeNormalize(float3(viewDirection), float3(0, 0, 1));
+    float perceptualRoughness = clamp(float(roughness), 0.045, 1.0);
+    float3 R = reflect(-V, N);
+    uint mipCount = environmentMap.get_num_mip_levels();
+    float lod = perceptualRoughness * float(max(int(mipCount) - 1, 0));
+    float3 prefilteredColor = float3(environmentMap.sample(environmentSampler, R, level(lod)).rgb);
+    float3 irradiance = sampleDiffuseIrradiance(environmentMap, environmentSampler, N);
+
+    float NdotV = clamp(dot(N, V), 1e-4, 1.0);
+    float3 baseAlbedo = float3(albedo);
+    float metallicValue = clamp(float(metallic), 0.0, 1.0);
+    float3 F0 = mix(float3(0.04), baseAlbedo, metallicValue);
+    float Fc = pow(1.0 - NdotV, 5.0);
+    float3 F = F0 + (1.0 - F0) * Fc;
+
+    float3 kS = F;
+    float3 kD = (float3(1.0) - kS) * (1.0 - metallicValue);
+
+    float2 brdfSample = float2(brdfLUT.sample(brdfSampler, float2(NdotV, perceptualRoughness)).rg);
+    float3 specular = prefilteredColor * (F0 * brdfSample.x + brdfSample.y);
+
+    float3 diffuse = irradiance * baseAlbedo * kD;
+    float3 color = (diffuse + specular) * float(clamp(ambientOcclusion, half(0), half(1)));
+    return half3(color);
+}
+
 float3 calcCovariance2D(float3 viewPos,
                         packed_half3 cov3Da,
                         packed_half3 cov3Db,
@@ -104,6 +179,8 @@ FragmentIn splatVertex(Splat splat,
         out.metallic = half(0);
         out.roughness = half(0);
         out.normal = half3(0);
+        out.worldPosition = float3(0);
+        out.viewDirection = float3(0);
         return out;
     }
 
@@ -125,7 +202,17 @@ FragmentIn splatVertex(Splat splat,
     out.albedo = half3(splat.albedo);
     out.metallic = splat.metallic;
     out.roughness = splat.roughness;
-    out.normal = half3(splat.normal);
+
+    float3 worldPosition = float3(splat.position);
+    float3 normal = safeNormalize(float3(splat.normal), float3(0, 0, 1));
+    float4 rotation = float4(splat.rotation);
+    float3 rotatedNormal = safeNormalize(rotateVectorByQuaternion(rotation, normal), float3(0, 0, 1));
+    out.normal = half3(rotatedNormal);
+    out.worldPosition = worldPosition;
+
+    float3 cameraPosition = uniforms.cameraPosition.xyz;
+    float3 viewDirection = safeNormalize(cameraPosition - worldPosition, float3(0, 0, 1));
+    out.viewDirection = viewDirection;
     return out;
 }
 

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -107,8 +107,31 @@ public class SplatRenderer {
         return sanitized
     }
 
+    private static func sanitizeQuaternion(_ quaternion: simd_quatf, pointIndex: Int) -> simd_quatf {
+        let vector = quaternion.vector
+        guard vector.x.isFinite, vector.y.isFinite, vector.z.isFinite, vector.w.isFinite else {
+            log.error("Non-finite rotation for splat index \(pointIndex, privacy: .public); using identity quaternion")
+            return simd_quatf()
+        }
+
+        let lengthSquared = simd_length_squared(vector)
+        guard lengthSquared.isFinite, lengthSquared > .leastNonzeroMagnitude else {
+            log.error("Invalid rotation magnitude for splat index \(pointIndex, privacy: .public); using identity quaternion")
+            return simd_quatf()
+        }
+
+        return simd_normalize(quaternion)
+    }
+
     private static func packHalf3(_ vector: SIMD3<Float>) -> PackedHalf3 {
         PackedHalf3(x: Float16(vector.x), y: Float16(vector.y), z: Float16(vector.z))
+    }
+
+    private static func packHalf4(_ vector: SIMD4<Float>) -> PackedHalf4 {
+        PackedHalf4(x: Float16(vector.x),
+                    y: Float16(vector.y),
+                    z: Float16(vector.z),
+                    w: Float16(vector.w))
     }
 
     private static func makeFallbackEnvironmentMap(device: MTLDevice) -> MTLTexture {
@@ -213,9 +236,12 @@ public class SplatRenderer {
         var projectionMatrix: matrix_float4x4
         var viewMatrix: matrix_float4x4
         var screenSize: SIMD2<UInt32> // Size of screen in pixels
+        var screenPadding: SIMD2<UInt32> = .zero
+        var cameraPosition: SIMD4<Float>
 
         var splatCount: UInt32
         var indexedSplatCount: UInt32
+        var paddingCounts: SIMD2<UInt32> = .zero
     }
 
     // Keep in sync with Shaders.metal : UniformsArray
@@ -242,6 +268,13 @@ public class SplatRenderer {
         var z: Float16
     }
 
+    struct PackedHalf4 {
+        var x: Float16
+        var y: Float16
+        var z: Float16
+        var w: Float16
+    }
+
     struct PackedRGBHalf4 {
         var r: Float16
         var g: Float16
@@ -259,6 +292,7 @@ public class SplatRenderer {
         var metallic: Float16
         var roughness: Float16
         var normal: PackedHalf3
+        var rotation: PackedHalf4
     }
 
     struct SplatIndexAndDepth {
@@ -644,9 +678,11 @@ public class SplatRenderer {
                                 splatCount: UInt32,
                                 indexedSplatCount: UInt32) {
         for (i, viewport) in viewports.enumerated() where i <= maxViewCount {
+            let cameraPosition = Self.cameraWorldPosition(forViewMatrix: viewport.viewMatrix)
             let uniforms = Uniforms(projectionMatrix: viewport.projectionMatrix,
                                     viewMatrix: viewport.viewMatrix,
                                     screenSize: SIMD2(x: UInt32(viewport.screenSize.x), y: UInt32(viewport.screenSize.y)),
+                                    cameraPosition: SIMD4<Float>(cameraPosition, 1),
                                     splatCount: splatCount,
                                     indexedSplatCount: indexedSplatCount)
             self.uniforms.pointee.setUniforms(index: i, uniforms)
@@ -813,6 +849,7 @@ public class SplatRenderer {
             renderEncoder.setRenderPipelineState(postprocessPipelineState)
             renderEncoder.setDepthStencilState(postprocessDepthState)
             renderEncoder.setCullMode(.none)
+            bindMaterialResources(to: renderEncoder)
             renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
             renderEncoder.popDebugGroup()
         } else {
@@ -900,7 +937,8 @@ extension SplatRenderer.Splat {
          roughness: Float,
          normal: SIMD3<Float>,
          pointIndex: Int) {
-        let transform = simd_float3x3(rotation) * simd_float3x3(diagonal: scale)
+        let sanitizedRotation = SplatRenderer.sanitizeQuaternion(rotation, pointIndex: pointIndex)
+        let transform = simd_float3x3(sanitizedRotation) * simd_float3x3(diagonal: scale)
         let cov3D = transform * transform.transpose
 
         let sanitizedColor = SplatRenderer.sanitizeColor(color, pointIndex: pointIndex)
@@ -937,6 +975,7 @@ extension SplatRenderer.Splat {
         self.metallic = Float16(sanitizedMetallic)
         self.roughness = Float16(sanitizedRoughness)
         self.normal = SplatRenderer.packHalf3(sanitizedNormal)
+        self.rotation = SplatRenderer.packHalf4(sanitizedRotation.vector)
     }
 }
 

--- a/MetalSplatter/Tests/SplatRendererTests.swift
+++ b/MetalSplatter/Tests/SplatRendererTests.swift
@@ -29,6 +29,10 @@ final class SplatRendererPackingTests: XCTestCase {
         XCTAssertEqual(Float(splat.normal.y), 1, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.normal.z), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.a), 0.8, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.x), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.y), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.z), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.w), 1, accuracy: 1e-3)
     }
 
     func testInvalidMaterialValuesFallBackToDefaults() {
@@ -56,6 +60,22 @@ final class SplatRendererPackingTests: XCTestCase {
         XCTAssertEqual(Float(splat.color.y), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.z), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.a), 0, accuracy: 1e-3)
+    }
+
+    func testInvalidRotationFallsBackToIdentity() {
+        var point = SplatScenePoint(position: .zero,
+                                    color: .linearFloat(SIMD3<Float>(repeating: 0.5)),
+                                    opacity: .linearFloat(0.5),
+                                    scale: .linearFloat(SIMD3<Float>(repeating: 1)),
+                                    rotation: simd_quatf())
+        point.rotation = simd_quatf(vector: SIMD4<Float>(repeating: .nan))
+
+        let splat = SplatRenderer.Splat(point, index: 3)
+
+        XCTAssertEqual(Float(splat.rotation.x), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.y), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.z), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.rotation.w), 1, accuracy: 1e-3)
     }
 
     func testSplatStrideMatchesSize() throws {
@@ -94,6 +114,37 @@ final class SplatRendererPackingTests: XCTestCase {
                 return
             }
             XCTAssertEqual(resource, "environmentMap")
+        }
+    }
+
+    func testRejectsInvalidBRDFTextureType() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal device unavailable in test environment")
+        }
+
+        let renderer = try SplatRenderer(device: device,
+                                         colorFormat: .bgra8Unorm,
+                                         depthFormat: .invalid,
+                                         sampleCount: 1,
+                                         maxViewCount: 1,
+                                         maxSimultaneousRenders: 1)
+
+        let descriptor = MTLTextureDescriptor.textureCubeDescriptor(pixelFormat: .rg16Float,
+                                                                    size: 1,
+                                                                    mipmapped: false)
+        descriptor.usage = [.shaderRead]
+
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            XCTFail("Failed to allocate test texture")
+            return
+        }
+
+        XCTAssertThrowsError(try renderer.setBRDFLookupTexture(texture)) { error in
+            guard case SplatRenderer.Error.invalidMaterialResource(let resource, _) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertEqual(resource, "brdfLUT")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GGX-based shading utilities and integrate BRDF/environment sampling into the single- and multi-stage render paths
- extend uniforms and splat packing with camera position and quaternion rotation so shaders receive world normals and view directions
- update renderer resource binding and add unit tests covering quaternion sanitisation plus BRDF LUT validation

## Testing
- swift test *(fails: Metal and os frameworks unavailable in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4750827c83219b89635f269805bd