### PR TITLE
Integrate Vision Pro environment probe lighting

### DIFF
--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -9,10 +9,13 @@
 /* Begin PBXBuildFile section */
 		147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147AFBCE2E33ED730052B2AD /* CameraController.swift */; };
 		147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147AFBCF2E33ED730052B2AD /* InteractiveMTKView.swift */; };
-		610347D92B46864500693CE3 /* SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DF62B41551F00302B57 /* SampleApp.swift */; };
-		610347DA2B46874500693CE3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DF72B41551F00302B57 /* ContentView.swift */; };
-		610347DB2B46875700693CE3 /* VisionSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */; };
-		610347DC2B46875A00693CE3 /* ContentStageConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */; };
+                610347D92B46864500693CE3 /* SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DF62B41551F00302B57 /* SampleApp.swift */; };
+                610347DA2B46874500693CE3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DF72B41551F00302B57 /* ContentView.swift */; };
+                610347DB2B46875700693CE3 /* VisionSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */; };
+                610347DC2B46875A00693CE3 /* ContentStageConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */; };
+                61A1AA012B7C000100A1AA00 /* EnvironmentProbeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A1AA002B7C000100A1AA00 /* EnvironmentProbeManager.swift */; };
+                61A1AA072B7C000100A1AA00 /* EnvironmentPrefilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */; };
+                61A1AA0B2B7C000100A1AA00 /* EnvironmentPrefilter.metal in Sources */ = {isa = PBXBuildFile; fileRef = 61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */; };
 		61791DCF2B41544300302B57 /* Assets.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = 61791DC32B41514300302B57 /* Assets.xcassets */; };
 		61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DDA2B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift */; };
 		61791DE22B4154FB00302B57 /* ModelIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791DDB2B4154FB00302B57 /* ModelIdentifier.swift */; };
@@ -44,7 +47,10 @@
 		61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisionSceneRenderer.swift; sourceTree = "<group>"; };
 		61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneRenderer.swift; sourceTree = "<group>"; };
 		61791E112B416DCF00302B57 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		61791E142B42294700302B57 /* MetalKitSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneView.swift; sourceTree = "<group>"; };
+                61791E142B42294700302B57 /* MetalKitSceneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalKitSceneView.swift; sourceTree = "<group>"; };
+                61A1AA002B7C000100A1AA00 /* EnvironmentProbeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProbeManager.swift; sourceTree = "<group>"; };
+                61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentPrefilter.swift; sourceTree = "<group>"; };
+                61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = EnvironmentPrefilter.metal; sourceTree = "<group>"; };
 		617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -74,20 +80,31 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		610347E02B468A0000693CE3 /* Scene */ = {
-			isa = PBXGroup;
-			children = (
-				147AFBCE2E33ED730052B2AD /* CameraController.swift */,
-				147AFBCF2E33ED730052B2AD /* InteractiveMTKView.swift */,
-				610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */,
-				61791DF72B41551F00302B57 /* ContentView.swift */,
-				61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
-				61791E142B42294700302B57 /* MetalKitSceneView.swift */,
-				61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
-			);
-			path = Scene;
-			sourceTree = "<group>";
-		};
+                610347E02B468A0000693CE3 /* Scene */ = {
+                        isa = PBXGroup;
+                        children = (
+                                147AFBCE2E33ED730052B2AD /* CameraController.swift */,
+                                147AFBCF2E33ED730052B2AD /* InteractiveMTKView.swift */,
+                                610347D82B46861E00693CE3 /* ContentStageConfiguration.swift */,
+                                61791DF72B41551F00302B57 /* ContentView.swift */,
+                                61A1AA0C2B7C000100A1AA00 /* Shaders */,
+                                61A1AA002B7C000100A1AA00 /* EnvironmentProbeManager.swift */,
+                                61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */,
+                                61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
+                                61791E142B42294700302B57 /* MetalKitSceneView.swift */,
+                                61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
+                        );
+                        path = Scene;
+                        sourceTree = "<group>";
+                };
+                61A1AA0C2B7C000100A1AA00 /* Shaders */ = {
+                        isa = PBXGroup;
+                        children = (
+                                61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */,
+                        );
+                        path = Shaders;
+                        sourceTree = "<group>";
+                };
 		610347E12B468A0B00693CE3 /* Util */ = {
 			isa = PBXGroup;
 			children = (
@@ -207,20 +224,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		617E50AC2B314BE200F99766 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				61791DE22B4154FB00302B57 /* ModelIdentifier.swift in Sources */,
-				610347DA2B46874500693CE3 /* ContentView.swift in Sources */,
-				61791DE42B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift in Sources */,
-				61791DEA2B4154FB00302B57 /* MatrixMathUtil.swift in Sources */,
-				610347DB2B46875700693CE3 /* VisionSceneRenderer.swift in Sources */,
-				610347D92B46864500693CE3 /* SampleApp.swift in Sources */,
-				61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */,
-				61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */,
-				147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */,
-				147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
+                617E50AC2B314BE200F99766 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                61A1AA012B7C000100A1AA00 /* EnvironmentProbeManager.swift in Sources */,
+                                61791DE22B4154FB00302B57 /* ModelIdentifier.swift in Sources */,
+                                610347DA2B46874500693CE3 /* ContentView.swift in Sources */,
+                                61A1AA0B2B7C000100A1AA00 /* EnvironmentPrefilter.metal in Sources */,
+                                61791DE42B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift in Sources */,
+                                61791DEA2B4154FB00302B57 /* MatrixMathUtil.swift in Sources */,
+                                610347DB2B46875700693CE3 /* VisionSceneRenderer.swift in Sources */,
+                                610347D92B46864500693CE3 /* SampleApp.swift in Sources */,
+                                61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */,
+                                61A1AA072B7C000100A1AA00 /* EnvironmentPrefilter.swift in Sources */,
+                                61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */,
+                                147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */,
+                                147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
 				61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
 				61791DCF2B41544300302B57 /* Assets.xcassets in Sources */,
 				61791E132B416DD700302B57 /* Constants.swift in Sources */,

--- a/SampleApp/Scene/EnvironmentPrefilter.swift
+++ b/SampleApp/Scene/EnvironmentPrefilter.swift
@@ -1,0 +1,258 @@
+#if os(visionOS)
+
+import Foundation
+import Metal
+import os
+
+struct EnvironmentPrefilterResult {
+    let environmentMap: MTLTexture
+    let brdfLookup: MTLTexture
+    let revision: UInt64
+    let timestamp: Date
+    let sphericalHarmonics: [Float]
+}
+
+private struct PrefilterUniforms {
+    var mipLevel: UInt32
+    var dimension: UInt32
+    var roughness: Float
+    var sampleCount: UInt32
+}
+
+private struct DiffuseUniforms {
+    var mipLevel: UInt32
+    var dimension: UInt32
+    var sampleCount: UInt32
+}
+
+private struct BRDFUniforms {
+    var dimension: UInt32
+    var sampleCount: UInt32
+}
+
+final class EnvironmentPrefilter {
+    enum Error: Swift.Error {
+        case missingCommandQueue
+        case missingPipeline(function: String)
+        case unsupportedTextureType(MTLTextureType)
+        case unsupportedPixelFormat(MTLPixelFormat)
+        case commandBufferFailed
+    }
+
+    private static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "EnvironmentPrefilter",
+                                     category: "EnvironmentPrefilter")
+
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let specularPipeline: MTLComputePipelineState
+    private let diffusePipeline: MTLComputePipelineState
+    private let brdfPipeline: MTLComputePipelineState
+
+    private let targetMapSize: Int
+    private let diffuseSampleCount: UInt32
+    private let specularSampleCount: UInt32
+    private let brdfSampleCount: UInt32
+    private let brdfResolution: Int
+
+    private var cachedBRDFLUT: MTLTexture?
+
+    init(device: MTLDevice,
+         mapSize: Int = 256,
+         specularSamples: UInt32 = 256,
+         diffuseSamples: UInt32 = 128,
+         brdfResolution: Int = 256,
+         brdfSamples: UInt32 = 512) throws {
+        self.device = device
+        guard let queue = device.makeCommandQueue() else {
+            throw Error.missingCommandQueue
+        }
+        self.commandQueue = queue
+        self.targetMapSize = mapSize
+        self.specularSampleCount = specularSamples
+        self.diffuseSampleCount = diffuseSamples
+        self.brdfResolution = brdfResolution
+        self.brdfSampleCount = brdfSamples
+
+        let library = try device.makeDefaultLibrary(bundle: Bundle.main)
+        guard let specularFunction = library.makeFunction(name: "prefilterEnvironmentSpecular") else {
+            throw Error.missingPipeline(function: "prefilterEnvironmentSpecular")
+        }
+        guard let diffuseFunction = library.makeFunction(name: "prefilterEnvironmentDiffuse") else {
+            throw Error.missingPipeline(function: "prefilterEnvironmentDiffuse")
+        }
+        guard let brdfFunction = library.makeFunction(name: "integrateBRDFLUT") else {
+            throw Error.missingPipeline(function: "integrateBRDFLUT")
+        }
+
+        specularPipeline = try device.makeComputePipelineState(function: specularFunction)
+        diffusePipeline = try device.makeComputePipelineState(function: diffuseFunction)
+        brdfPipeline = try device.makeComputePipelineState(function: brdfFunction)
+    }
+
+    func prefilter(snapshot: EnvironmentProbeManager.Snapshot) throws -> EnvironmentPrefilterResult {
+        guard snapshot.texture.textureType == .typeCube else {
+            throw Error.unsupportedTextureType(snapshot.texture.textureType)
+        }
+
+        guard let sourceTexture = sanitizedSourceTexture(from: snapshot.texture) else {
+            throw Error.unsupportedPixelFormat(snapshot.texture.pixelFormat)
+        }
+
+        let environmentTexture = try makeEnvironmentTexture()
+        try encodePrefilter(from: sourceTexture, to: environmentTexture)
+        let brdf = try makeBRDFLookupTexture()
+
+        return EnvironmentPrefilterResult(environmentMap: environmentTexture,
+                                          brdfLookup: brdf,
+                                          revision: snapshot.revision,
+                                          timestamp: snapshot.timestamp,
+                                          sphericalHarmonics: snapshot.sphericalHarmonics)
+    }
+
+    private func sanitizedSourceTexture(from texture: MTLTexture) -> MTLTexture? {
+        if texture.pixelFormat == .rgba16Float || texture.pixelFormat == .rgba32Float {
+            return texture
+        }
+        return texture.makeTextureView(pixelFormat: .rgba16Float)
+    }
+
+    private func makeEnvironmentTexture() throws -> MTLTexture {
+        let descriptor = MTLTextureDescriptor.textureCubeDescriptor(pixelFormat: .rgba16Float,
+                                                                     size: targetMapSize,
+                                                                     mipmapped: true)
+        descriptor.usage = [.shaderRead, .shaderWrite]
+        descriptor.storageMode = .private
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            throw Error.unsupportedPixelFormat(.rgba16Float)
+        }
+        texture.label = "PrefilteredEnvironmentCube"
+        return texture
+    }
+
+    private func makeBRDFLookupTexture() throws -> MTLTexture {
+        if let cachedBRDFLUT {
+            return cachedBRDFLUT
+        }
+
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rg16Float,
+                                                                   width: brdfResolution,
+                                                                   height: brdfResolution,
+                                                                   mipmapped: false)
+        descriptor.usage = [.shaderRead, .shaderWrite]
+        descriptor.storageMode = .private
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            throw Error.unsupportedPixelFormat(.rg16Float)
+        }
+        texture.label = "PrefilteredBRDFLUT"
+
+        try encodeBRDF(into: texture)
+        cachedBRDFLUT = texture
+        return texture
+    }
+
+    private func encodePrefilter(from source: MTLTexture, to destination: MTLTexture) throws {
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else {
+            throw Error.missingCommandQueue
+        }
+        commandBuffer.label = "EnvironmentPrefilter"
+
+        let mipCount = destination.mipmapLevelCount
+        var dimension = destination.width
+        let uniformBuffer = device.makeBuffer(length: MemoryLayout<PrefilterUniforms>.stride,
+                                              options: .storageModeShared)
+        let diffuseBuffer = device.makeBuffer(length: MemoryLayout<DiffuseUniforms>.stride,
+                                              options: .storageModeShared)
+
+        for mipLevel in 0..<mipCount {
+            let encoder = commandBuffer.makeComputeCommandEncoder()
+            encoder?.label = "SpecularPrefilterMip\(mipLevel)"
+            encoder?.setComputePipelineState(specularPipeline)
+            encoder?.setTexture(source, index: 0)
+            encoder?.setTexture(destination, index: 1)
+
+            var uniforms = PrefilterUniforms(mipLevel: UInt32(mipLevel),
+                                             dimension: UInt32(dimension),
+                                             roughness: Float(mipCount <= 1 ? 0 : Float(mipLevel) / Float(mipCount - 1)),
+                                             sampleCount: specularSampleCount)
+            if let buffer = uniformBuffer {
+                memcpy(buffer.contents(), &uniforms, MemoryLayout<PrefilterUniforms>.stride)
+                encoder?.setBuffer(buffer, offset: 0, index: 0)
+            }
+
+            let threadsPerGroup = MTLSize(width: 8, height: 8, depth: 1)
+            let threadgroups = MTLSize(width: max(1, (dimension + 7) / 8),
+                                       height: max(1, (dimension + 7) / 8),
+                                       depth: 6)
+            encoder?.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+            encoder?.endEncoding()
+
+            dimension = max(1, dimension >> 1)
+        }
+
+        if let diffuseBuffer, mipCount > 0 {
+            let diffuseEncoder = commandBuffer.makeComputeCommandEncoder()
+            diffuseEncoder?.label = "DiffusePrefilter"
+            diffuseEncoder?.setComputePipelineState(diffusePipeline)
+            diffuseEncoder?.setTexture(source, index: 0)
+            diffuseEncoder?.setTexture(destination, index: 1)
+            let diffuseMipLevel = mipCount - 1
+            let diffuseDimension = max(1, destination.width >> diffuseMipLevel)
+            var uniforms = DiffuseUniforms(mipLevel: UInt32(diffuseMipLevel),
+                                           dimension: UInt32(diffuseDimension),
+                                           sampleCount: diffuseSampleCount)
+            memcpy(diffuseBuffer.contents(), &uniforms, MemoryLayout<DiffuseUniforms>.stride)
+            diffuseEncoder?.setBuffer(diffuseBuffer, offset: 0, index: 0)
+            let threadsPerGroup = MTLSize(width: 1, height: 1, depth: 1)
+            let threadgroups = MTLSize(width: diffuseDimension,
+                                       height: diffuseDimension,
+                                       depth: 6)
+            diffuseEncoder?.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+            diffuseEncoder?.endEncoding()
+        }
+
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        if commandBuffer.status == .error {
+            let description = commandBuffer.error?.localizedDescription ?? "unknown"
+            Self.log.error("Environment prefilter command buffer failed: \(description)")
+            throw Error.commandBufferFailed
+        }
+    }
+
+    private func encodeBRDF(into texture: MTLTexture) throws {
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else {
+            throw Error.missingCommandQueue
+        }
+        commandBuffer.label = "BRDFIntegration"
+
+        let encoder = commandBuffer.makeComputeCommandEncoder()
+        encoder?.label = "IntegrateBRDF"
+        encoder?.setComputePipelineState(brdfPipeline)
+        encoder?.setTexture(texture, index: 0)
+
+        var uniforms = BRDFUniforms(dimension: UInt32(brdfResolution),
+                                     sampleCount: brdfSampleCount)
+        let uniformBuffer = device.makeBuffer(bytes: &uniforms,
+                                              length: MemoryLayout<BRDFUniforms>.stride,
+                                              options: .storageModeShared)
+        encoder?.setBuffer(uniformBuffer, offset: 0, index: 0)
+
+        let threadsPerGroup = MTLSize(width: 8, height: 8, depth: 1)
+        let threadgroups = MTLSize(width: (brdfResolution + 7) / 8,
+                                   height: (brdfResolution + 7) / 8,
+                                   depth: 1)
+        encoder?.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+        encoder?.endEncoding()
+
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        if commandBuffer.status == .error {
+            Self.log.error("BRDF integration command buffer failed: \(commandBuffer.error?.localizedDescription ?? "unknown")")
+            throw Error.commandBufferFailed
+        }
+    }
+}
+
+#endif // os(visionOS)

--- a/SampleApp/Scene/EnvironmentProbeManager.swift
+++ b/SampleApp/Scene/EnvironmentProbeManager.swift
@@ -1,0 +1,158 @@
+#if os(visionOS)
+
+import ARKit
+import Foundation
+import Metal
+import os
+
+final class EnvironmentProbeManager: NSObject {
+    struct Snapshot {
+        let texture: MTLTexture
+        let revision: UInt64
+        let timestamp: Date
+        let sphericalHarmonics: [Float]
+    }
+
+    private static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "EnvironmentProbeManager",
+                                     category: "EnvironmentProbe")
+
+    private let session: ARSession
+    private let device: MTLDevice
+    private let stateQueue = DispatchQueue(label: "com.metalsplatter.environmentProbe.state")
+
+    private var latestSnapshot: Snapshot?
+    private var deliveredRevision: UInt64 = 0
+    private var isRunning = false
+
+    override init() {
+        guard let defaultDevice = MTLCreateSystemDefaultDevice() else {
+            fatalError("EnvironmentProbeManager requires a Metal device")
+        }
+        self.device = defaultDevice
+        self.session = ARSession()
+        super.init()
+        self.session.delegate = self
+    }
+
+    init(device: MTLDevice) {
+        self.device = device
+        self.session = ARSession()
+        super.init()
+        self.session.delegate = self
+    }
+
+    func start() {
+        guard !isRunning else { return }
+
+        let configuration = ARWorldTrackingConfiguration()
+        configuration.environmentTexturing = .automatic
+
+        session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+        isRunning = true
+        Self.log.debug("Started ARSession with automatic environment texturing")
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        session.pause()
+        isRunning = false
+        Self.log.debug("Stopped ARSession environment probe updates")
+    }
+
+    func consumeLatestSnapshot() -> Snapshot? {
+        stateQueue.sync {
+            guard let snapshot = latestSnapshot else { return nil }
+            guard snapshot.revision != deliveredRevision else { return nil }
+            deliveredRevision = snapshot.revision
+            return snapshot
+        }
+    }
+
+    private func updateSnapshot(with texture: MTLTexture?, sphericalHarmonics: [Float], timestamp: Date) {
+        guard let texture else {
+            Self.log.error("Received environment probe without texture")
+            return
+        }
+
+        guard texture.device === device else {
+            Self.log.error("Environment texture device mismatch; expected \(device), received \(String(describing: texture.device))")
+            return
+        }
+
+        assignSnapshot(texture: texture,
+                       sphericalHarmonics: sphericalHarmonics,
+                       timestamp: timestamp)
+    }
+
+    private func assignSnapshot(texture: MTLTexture, sphericalHarmonics: [Float], timestamp: Date) {
+        stateQueue.async {
+            let revision = (self.latestSnapshot?.revision ?? 0) &+ 1
+            self.latestSnapshot = Snapshot(texture: texture,
+                                           revision: revision,
+                                           timestamp: timestamp,
+                                           sphericalHarmonics: sphericalHarmonics)
+            Self.log.debug("Updated environment probe snapshot (revision: \(revision))")
+        }
+    }
+
+    private func currentSphericalHarmonics(from frame: ARFrame?) -> [Float] {
+        guard let coefficients = frame?.lightEstimate?.sphericalHarmonicsCoefficients else { return [] }
+        return coefficients.map { Float(truncating: $0) }
+    }
+}
+
+extension EnvironmentProbeManager: ARSessionDelegate {
+    func session(_ session: ARSession, didUpdate frame: ARFrame) {
+        guard isRunning else { return }
+        let harmonics = currentSphericalHarmonics(from: frame)
+        if harmonics.isEmpty {
+            Self.log.debug("No spherical harmonics coefficients available in current frame")
+        }
+        if let probeTexture = frame.environmentTexture {
+            updateSnapshot(with: probeTexture,
+                           sphericalHarmonics: harmonics,
+                           timestamp: Date())
+        }
+    }
+
+    func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
+        handleProbeAnchors(anchors)
+    }
+
+    func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
+        handleProbeAnchors(anchors)
+    }
+
+    private func handleProbeAnchors(_ anchors: [ARAnchor]) {
+        guard isRunning else { return }
+        var handled = false
+        for anchor in anchors {
+            guard let probe = anchor as? AREnvironmentProbeAnchor else { continue }
+            handled = true
+            let harmonics = currentSphericalHarmonics(from: session.currentFrame)
+            updateSnapshot(with: probe.environmentTexture,
+                           sphericalHarmonics: harmonics,
+                           timestamp: Date())
+        }
+        if !handled {
+            Self.log.debug("Received anchor update without environment probe")
+        }
+    }
+
+    func session(_ session: ARSession, didFailWithError error: Error) {
+        Self.log.error("Environment probe session failed: \(error.localizedDescription)")
+    }
+
+    func sessionWasInterrupted(_ session: ARSession) {
+        Self.log.warning("Environment probe session interrupted")
+    }
+
+    func sessionInterruptionEnded(_ session: ARSession) {
+        Self.log.info("Environment probe session interruption ended")
+        if isRunning {
+            start()
+        }
+    }
+}
+
+#endif // os(visionOS)

--- a/SampleApp/Scene/Shaders/EnvironmentPrefilter.metal
+++ b/SampleApp/Scene/Shaders/EnvironmentPrefilter.metal
@@ -1,0 +1,212 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct PrefilterUniforms {
+    uint mipLevel;
+    uint dimension;
+    float roughness;
+    uint sampleCount;
+};
+
+struct DiffuseUniforms {
+    uint mipLevel;
+    uint dimension;
+    uint sampleCount;
+};
+
+struct BRDFUniforms {
+    uint dimension;
+    uint sampleCount;
+};
+
+static inline float radicalInverse_VdC(uint bits) {
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10f; // / 0x100000000
+}
+
+static inline float2 hammersley(uint i, uint N) {
+    return float2(float(i) / float(N), radicalInverse_VdC(i));
+}
+
+static inline float3 hemisphereDirection(uint faceIndex, float2 uv) {
+    float2 xy = 2.0f * uv - 1.0f;
+    switch (faceIndex) {
+        case 0: return normalize(float3(1.0f, -xy.y, -xy.x));
+        case 1: return normalize(float3(-1.0f, -xy.y, xy.x));
+        case 2: return normalize(float3(xy.x, 1.0f, xy.y));
+        case 3: return normalize(float3(xy.x, -1.0f, -xy.y));
+        case 4: return normalize(float3(xy.x, -xy.y, 1.0f));
+        default: return normalize(float3(-xy.x, -xy.y, -1.0f));
+    }
+}
+
+static inline float3 importanceSampleGGX(float2 Xi, float roughness, float3 N) {
+    float a = roughness * roughness;
+    float phi = 2.0f * M_PI_F * Xi.x;
+    float cosTheta = sqrt(max(0.0f, (1.0f - Xi.y) / (1.0f + (a * a - 1.0f) * Xi.y)));
+    float sinTheta = sqrt(max(0.0f, 1.0f - cosTheta * cosTheta));
+
+    float3 H;
+    H.x = cos(phi) * sinTheta;
+    H.y = sin(phi) * sinTheta;
+    H.z = cosTheta;
+
+    float3 up = fabs(N.z) < 0.999f ? float3(0.0f, 0.0f, 1.0f) : float3(1.0f, 0.0f, 0.0f);
+    float3 tangentX = normalize(cross(up, N));
+    float3 tangentY = cross(N, tangentX);
+
+    return normalize(tangentX * H.x + tangentY * H.y + N * H.z);
+}
+
+static inline float distributionGGX(float NdotH, float roughness) {
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float denom = NdotH * NdotH * (a2 - 1.0f) + 1.0f;
+    return a2 / max(1e-4f, M_PI_F * denom * denom);
+}
+
+static inline float geometrySchlickGGX(float NdotV, float roughness) {
+    float r = roughness + 1.0f;
+    float k = (r * r) / 8.0f;
+    return NdotV / max(1e-4f, NdotV * (1.0f - k) + k);
+}
+
+static inline float geometrySmith(float3 N, float3 V, float3 L, float roughness) {
+    float NdotV = max(dot(N, V), 0.0f);
+    float NdotL = max(dot(N, L), 0.0f);
+    float ggx1 = geometrySchlickGGX(NdotV, roughness);
+    float ggx2 = geometrySchlickGGX(NdotL, roughness);
+    return ggx1 * ggx2;
+}
+
+static inline float3 sampleEnvironment(texturecube<float, access::sample> source, sampler cubeSampler, float3 dir) {
+    return source.sample(cubeSampler, dir).xyz;
+}
+
+kernel void prefilterEnvironmentSpecular(texturecube<float, access::sample> source [[texture(0)]],
+                                         texturecube<half, access::write> destination [[texture(1)]],
+                                         constant PrefilterUniforms &uniforms [[buffer(0)]],
+                                         uint3 gid [[thread_position_in_grid]]) {
+    if (gid.x >= uniforms.dimension || gid.y >= uniforms.dimension || gid.z >= 6) {
+        return;
+    }
+
+    constexpr sampler cubeSampler(filter::linear, address::clamp_to_edge);
+
+    float2 uv = (float2(gid.xy) + 0.5f) / float(uniforms.dimension);
+    float3 N = hemisphereDirection(gid.z, uv);
+    float3 V = N;
+    float roughness = max(uniforms.roughness, 0.045f);
+
+    uint sampleCount = max(uniforms.sampleCount, 1u);
+    float3 prefiltered = float3(0.0f);
+    float totalWeight = 0.0f;
+
+    for (uint i = 0; i < sampleCount; ++i) {
+        float2 Xi = hammersley(i, sampleCount);
+        float3 H = importanceSampleGGX(Xi, roughness, N);
+        float3 L = normalize(2.0f * dot(V, H) * H - V);
+        float NdotL = max(dot(N, L), 0.0f);
+        if (NdotL > 0.0f) {
+            prefiltered += sampleEnvironment(source, cubeSampler, L) * NdotL;
+            totalWeight += NdotL;
+        }
+    }
+
+    if (totalWeight > 0.0f) {
+        prefiltered /= totalWeight;
+    }
+
+    destination.write(half4(half3(prefiltered), half(1.0f)), uint2(gid.xy), gid.z, uniforms.mipLevel);
+}
+
+kernel void prefilterEnvironmentDiffuse(texturecube<float, access::sample> source [[texture(0)]],
+                                        texturecube<half, access::write> destination [[texture(1)]],
+                                        constant DiffuseUniforms &uniforms [[buffer(0)]],
+                                        uint3 gid [[thread_position_in_grid]]) {
+    if (gid.x >= uniforms.dimension || gid.y >= uniforms.dimension || gid.z >= 6) {
+        return;
+    }
+
+    constexpr sampler cubeSampler(filter::linear, address::clamp_to_edge);
+
+    float2 uv = (float2(gid.xy) + 0.5f) / float(uniforms.dimension);
+    float3 N = hemisphereDirection(gid.z, uv);
+
+    uint sampleCount = max(uniforms.sampleCount, 1u);
+    float3 diffuse = float3(0.0f);
+    float totalWeight = 0.0f;
+
+    for (uint i = 0; i < sampleCount; ++i) {
+        float2 Xi = hammersley(i, sampleCount);
+        float phi = 2.0f * M_PI_F * Xi.x;
+        float cosTheta = Xi.y;
+        float sinTheta = sqrt(max(0.0f, 1.0f - cosTheta * cosTheta));
+
+        float3 H = float3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+        float3 up = fabs(N.z) < 0.999f ? float3(0.0f, 0.0f, 1.0f) : float3(1.0f, 0.0f, 0.0f);
+        float3 tangentX = normalize(cross(up, N));
+        float3 tangentY = cross(N, tangentX);
+        float3 L = normalize(tangentX * H.x + tangentY * H.y + N * H.z);
+
+        float NdotL = max(dot(N, L), 0.0f);
+        if (NdotL > 0.0f) {
+            diffuse += sampleEnvironment(source, cubeSampler, L) * NdotL;
+            totalWeight += NdotL;
+        }
+    }
+
+    if (totalWeight > 0.0f) {
+        diffuse /= totalWeight;
+    }
+
+    destination.write(half4(half3(diffuse), half(1.0f)), uint2(gid.xy), gid.z, uniforms.mipLevel);
+}
+
+static inline float2 integrateBRDF(float NdotV, float roughness, uint sampleCount) {
+    float3 V = float3(sqrt(max(0.0f, 1.0f - NdotV * NdotV)), 0.0f, NdotV);
+    float A = 0.0f;
+    float B = 0.0f;
+    float3 N = float3(0.0f, 0.0f, 1.0f);
+
+    for (uint i = 0; i < sampleCount; ++i) {
+        float2 Xi = hammersley(i, sampleCount);
+        float3 H = importanceSampleGGX(Xi, roughness, N);
+        float3 L = normalize(2.0f * dot(V, H) * H - V);
+
+        float NdotL = max(L.z, 0.0f);
+        float NdotH = max(H.z, 0.0f);
+        float VdotH = max(dot(V, H), 0.0f);
+
+        if (NdotL > 0.0f) {
+            float G = geometrySmith(N, V, L, roughness);
+            float GVis = (G * VdotH) / max(1e-4f, NdotH * NdotV);
+            float Fc = pow(1.0f - VdotH, 5.0f);
+            A += (1.0f - Fc) * GVis;
+            B += Fc * GVis;
+        }
+    }
+
+    return float2(A, B) / float(sampleCount);
+}
+
+kernel void integrateBRDFLUT(texture2d<half, access::write> lut [[texture(0)]],
+                              constant BRDFUniforms &uniforms [[buffer(0)]],
+                              uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= uniforms.dimension || gid.y >= uniforms.dimension) {
+        return;
+    }
+
+    uint dimension = uniforms.dimension;
+    float NdotV = (float(gid.x) + 0.5f) / float(dimension);
+    float roughness = (float(gid.y) + 0.5f) / float(dimension);
+
+    uint sampleCount = max(uniforms.sampleCount, 1u);
+    float2 brdf = integrateBRDF(NdotV, roughness, sampleCount);
+
+    lut.write(half4(half(brdf.x), half(brdf.y), half(0.0f), half(1.0f)), gid);
+}

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -1,5 +1,6 @@
 #if os(visionOS)
 
+import ARKit
 import CompositorServices
 import Metal
 import MetalSplatter
@@ -36,6 +37,14 @@ class VisionSceneRenderer {
     let arSession: ARKitSession
     let worldTracking: WorldTrackingProvider
 
+    private let environmentProbeManager: EnvironmentProbeManager
+    private let environmentPrefilter: EnvironmentPrefilter?
+    private var environmentPrefilterResult: EnvironmentPrefilterResult?
+    private var environmentResourcesDirty = false
+    private var latestPrefilterRevision: UInt64 = 0
+    private var lastAppliedEnvironmentRevision: UInt64 = 0
+    private var lastPrefilterDuration: TimeInterval = 0
+
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
         self.device = layerRenderer.device
@@ -43,12 +52,23 @@ class VisionSceneRenderer {
 
         worldTracking = WorldTrackingProvider()
         arSession = ARKitSession()
+        environmentProbeManager = EnvironmentProbeManager(device: device)
+        do {
+            environmentPrefilter = try EnvironmentPrefilter(device: device)
+        } catch {
+            Self.log.error("Failed to initialize environment prefilter: \(error.localizedDescription)")
+            environmentPrefilter = nil
+        }
     }
 
     func load(_ model: ModelIdentifier?) async throws {
         guard model != self.model else { return }
         self.model = model
 
+        if let splat = modelRenderer as? SplatRenderer {
+            try? splat.setEnvironmentMap(nil)
+            try? splat.setBRDFLookupTexture(nil)
+        }
         modelRenderer = nil
         switch model {
         case .gaussianSplat(let url):
@@ -60,6 +80,10 @@ class VisionSceneRenderer {
                                           maxSimultaneousRenders: Constants.maxSimultaneousRenders)
             try await splat.read(from: url)
             modelRenderer = splat
+            if environmentPrefilterResult != nil {
+                environmentResourcesDirty = true
+                lastAppliedEnvironmentRevision = 0
+            }
         case .sampleBox:
             modelRenderer = try! SampleBoxRenderer(device: device,
                                                    colorFormat: layerRenderer.configuration.colorFormat,
@@ -79,6 +103,8 @@ class VisionSceneRenderer {
             } catch {
                 fatalError("Failed to initialize ARSession")
             }
+
+            environmentProbeManager.start()
 
             let renderThread = Thread {
                 self.renderLoop()
@@ -171,6 +197,8 @@ class VisionSceneRenderer {
         }
 
         updateRotation()
+        updateEnvironmentProbeIfNeeded()
+        applyEnvironmentResourcesIfNeeded()
 
         let viewports = self.viewports(drawable: drawable, deviceAnchor: deviceAnchor)
 
@@ -207,6 +235,47 @@ class VisionSceneRenderer {
                 }
             }
         }
+    }
+
+    private func updateEnvironmentProbeIfNeeded() {
+        guard let snapshot = environmentProbeManager.consumeLatestSnapshot() else { return }
+        guard snapshot.revision != latestPrefilterRevision else { return }
+        guard let prefilter = environmentPrefilter else {
+            Self.log.error("Environment prefilter unavailable when probe revision \(snapshot.revision) arrived")
+            return
+        }
+
+        do {
+            let start = Date()
+            let result = try prefilter.prefilter(snapshot: snapshot)
+            latestPrefilterRevision = snapshot.revision
+            environmentPrefilterResult = result
+            environmentResourcesDirty = true
+            lastPrefilterDuration = Date().timeIntervalSince(start)
+            let durationMS = lastPrefilterDuration * 1000.0
+            Self.log.debug("Prefiltered environment revision \(snapshot.revision) in \(durationMS) ms")
+        } catch {
+            Self.log.error("Failed to prefilter environment map: \(error.localizedDescription)")
+        }
+    }
+
+    private func applyEnvironmentResourcesIfNeeded() {
+        guard environmentResourcesDirty,
+              let result = environmentPrefilterResult,
+              let splatRenderer = modelRenderer as? SplatRenderer else { return }
+
+        do {
+            try splatRenderer.setEnvironmentMap(result.environmentMap)
+            try splatRenderer.setBRDFLookupTexture(result.brdfLookup)
+            environmentResourcesDirty = false
+            lastAppliedEnvironmentRevision = result.revision
+        } catch {
+            Self.log.error("Unable to bind environment resources: \(error.localizedDescription)")
+        }
+    }
+
+    deinit {
+        environmentProbeManager.stop()
     }
 }
 


### PR DESCRIPTION
## Summary
- add an EnvironmentProbeManager to start a Vision Pro ARSession with automatic environment texturing and surface probe updates to the renderer
- implement GPU-based environment prefiltering and BRDF LUT generation plus the supporting Metal shaders
- update VisionSceneRenderer to invoke the probe manager each frame, run prefiltering, and bind prefiltered textures to SplatRenderer while logging diagnostics
- register the new Swift and Metal sources in the sample app project so they build with the app bundle

## Testing
- `swift test` *(fails: missing Apple-only frameworks such as Metal/ARKit in the Linux CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68fd682f01bc8321b6ef3202ab08fc03