### PR TITLE
Improve environment prefilter error reporting

### DIFF
--- a/SampleApp/Scene/EnvironmentPrefilter.swift
+++ b/SampleApp/Scene/EnvironmentPrefilter.swift
@@ -31,12 +31,27 @@ private struct BRDFUniforms {
 }
 
 final class EnvironmentPrefilter {
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, LocalizedError {
         case missingCommandQueue
         case missingPipeline(function: String)
         case unsupportedTextureType(MTLTextureType)
         case unsupportedPixelFormat(MTLPixelFormat)
         case commandBufferFailed
+        
+        var errorDescription: String? {
+            switch self {
+            case .missingCommandQueue:
+                return "Environment prefilter could not create a Metal command queue."
+            case .missingPipeline(let function):
+                return "Environment prefilter pipeline function '\(function)' could not be created."
+            case .unsupportedTextureType(let type):
+                return "Environment prefilter received unsupported texture type: \(String(describing: type))."
+            case .unsupportedPixelFormat(let format):
+                return "Environment prefilter received unsupported pixel format: \(String(describing: format))."
+            case .commandBufferFailed:
+                return "Environment prefilter command buffer failed to complete successfully."
+            }
+        }
     }
 
     private static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "EnvironmentPrefilter",

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -258,7 +258,7 @@ class VisionSceneRenderer {
             let durationMS = lastPrefilterDuration * 1000.0
             Self.log.debug("Prefiltered environment revision \(snapshot.revision) in \(durationMS) ms")
         } catch {
-            Self.log.error("Failed to prefilter environment map: \(error.localizedDescription)")
+            Self.log.error("Failed to prefilter environment map: \(error.localizedDescription) (\(String(describing: error)))")
         }
     }
 


### PR DESCRIPTION
## Summary
- conform the environment prefilter error type to LocalizedError and add descriptive messages for each failure case
- expand the VisionSceneRenderer logging to include the enriched localized description and raw error value when prefiltering fails

## Testing
- swift build *(fails: platform modules such as Metal are unavailable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fda67a37e0832198a5e25949053281