### PR TITLE
Improve environment fallback shading and probe format handling

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -144,7 +144,11 @@ public class SplatRenderer {
         }
         texture.label = "SplatRendererFallbackEnvironment"
 
-        var pixel: [UInt8] = [0, 0, 0, 0]
+        // Use a neutral mid-gray fallback so splats remain visible even if the
+        // real environment map has not been bound yet. The shader multiplies
+        // the sampled irradiance by the splat albedo, so a value close to 0.9
+        // keeps colours readable without dramatically overexposing them.
+        var pixel: [UInt8] = [230, 230, 230, 255]
         let region = MTLRegionMake2D(0, 0, 1, 1)
         pixel.withUnsafeBytes { bytes in
             for slice in 0..<6 {
@@ -171,7 +175,10 @@ public class SplatRenderer {
         }
         texture.label = "SplatRendererFallbackBRDFLUT"
 
-        var pixel: [UInt8] = [0, 0]
+        // Match the neutral environment map by defaulting the BRDF LUT to a
+        // value that keeps the diffuse term untouched and avoids introducing
+        // spurious specular highlights.
+        var pixel: [UInt8] = [255, 0]
         let region = MTLRegionMake2D(0, 0, 1, 1)
         pixel.withUnsafeBytes { bytes in
             texture.replace(region: region,

--- a/SampleApp/Scene/EnvironmentPrefilter.swift
+++ b/SampleApp/Scene/EnvironmentPrefilter.swift
@@ -110,10 +110,20 @@ final class EnvironmentPrefilter {
     }
 
     private func sanitizedSourceTexture(from texture: MTLTexture) -> MTLTexture? {
-        if texture.pixelFormat == .rgba16Float || texture.pixelFormat == .rgba32Float {
+        switch texture.pixelFormat {
+        case .rgba16Float, .rgba32Float,
+             .rgba8Unorm, .rgba8Unorm_sRGB,
+             .bgra8Unorm, .bgra8Unorm_sRGB,
+             .bgr10_xr, .bgr10_xr_sRGB:
             return texture
+        default:
+            if let view = texture.makeTextureView(pixelFormat: .rgba16Float) {
+                Self.log.debug("Created float16 view for environment probe texture (format: \(texture.pixelFormat.rawValue))")
+                return view
+            }
+            Self.log.error("Unsupported environment probe pixel format: \(texture.pixelFormat.rawValue)")
+            return nil
         }
-        return texture.makeTextureView(pixelFormat: .rgba16Float)
     }
 
     private func makeEnvironmentTexture() throws -> MTLTexture {


### PR DESCRIPTION
## Summary
- keep splats visible when the environment map has not loaded by using non-black fallback textures
- accept common ARKit cube-map formats when prefiltering and log unsupported formats for easier diagnosis

## Testing
- `swift test` *(fails: missing Apple SDK modules in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe41176e1483219642ef9204ed9d9e