### PR TITLE
Enhance environment debugging diagnostics

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -134,6 +134,77 @@ public class SplatRenderer {
                     w: Float16(vector.w))
     }
 
+#if DEBUG
+    private static func describeMaterialDiagnostics(points: [SplatScenePoint]) -> String? {
+        guard !points.isEmpty else { return nil }
+
+        var albedoMin = SIMD3<Float>(repeating: .infinity)
+        var albedoMax = SIMD3<Float>(repeating: -.infinity)
+        var albedoSum = SIMD3<Float>(repeating: 0)
+
+        var opacityMin: Float = .infinity
+        var opacityMax: Float = -.infinity
+        var opacitySum: Float = 0
+
+        var metallicMin: Float = .infinity
+        var metallicMax: Float = -.infinity
+        var metallicSum: Float = 0
+
+        var roughnessMin: Float = .infinity
+        var roughnessMax: Float = -.infinity
+        var roughnessSum: Float = 0
+
+        for point in points {
+            let normalized = point.linearNormalized
+
+            let albedo = normalized.albedo
+            albedoMin = SIMD3<Float>(x: Swift.min(albedoMin.x, albedo.x),
+                                     y: Swift.min(albedoMin.y, albedo.y),
+                                     z: Swift.min(albedoMin.z, albedo.z))
+            albedoMax = SIMD3<Float>(x: Swift.max(albedoMax.x, albedo.x),
+                                     y: Swift.max(albedoMax.y, albedo.y),
+                                     z: Swift.max(albedoMax.z, albedo.z))
+            albedoSum += albedo
+
+            let opacity = normalized.opacity.asLinearFloat
+            opacityMin = Swift.min(opacityMin, opacity)
+            opacityMax = Swift.max(opacityMax, opacity)
+            opacitySum += opacity
+
+            let metallic = normalized.metallic
+            metallicMin = Swift.min(metallicMin, metallic)
+            metallicMax = Swift.max(metallicMax, metallic)
+            metallicSum += metallic
+
+            let roughness = normalized.roughness
+            roughnessMin = Swift.min(roughnessMin, roughness)
+            roughnessMax = Swift.max(roughnessMax, roughness)
+            roughnessSum += roughness
+        }
+
+        let count = Float(points.count)
+        let albedoAverage = albedoSum / count
+        let opacityAverage = opacitySum / count
+        let metallicAverage = metallicSum / count
+        let roughnessAverage = roughnessSum / count
+
+        func formatScalar(_ value: Float) -> String {
+            String(format: "%.3f", value)
+        }
+
+        func formatVector(_ vector: SIMD3<Float>) -> String {
+            "[\(formatScalar(vector.x)), \(formatScalar(vector.y)), \(formatScalar(vector.z))]"
+        }
+
+        let albedoSummary = "albedo avg \(formatVector(albedoAverage)) range \(formatVector(albedoMin))–\(formatVector(albedoMax))"
+        let opacitySummary = "opacity avg \(formatScalar(opacityAverage)) range \(formatScalar(opacityMin))–\(formatScalar(opacityMax))"
+        let metallicSummary = "metallic avg \(formatScalar(metallicAverage)) range \(formatScalar(metallicMin))–\(formatScalar(metallicMax))"
+        let roughnessSummary = "roughness avg \(formatScalar(roughnessAverage)) range \(formatScalar(roughnessMin))–\(formatScalar(roughnessMax))"
+
+        return "Loaded \(points.count) splats — \(albedoSummary), \(opacitySummary), \(metallicSummary), \(roughnessSummary)"
+    }
+#endif
+
     private static func makeFallbackEnvironmentMap(device: MTLDevice) -> MTLTexture {
         let descriptor = MTLTextureDescriptor.textureCubeDescriptor(pixelFormat: .rgba8Unorm,
                                                                     size: 1,
@@ -355,6 +426,10 @@ public class SplatRenderer {
     private let brdfSamplerState: MTLSamplerState
     private var environmentMapTexture: MTLTexture?
     private var brdfLookupTexture: MTLTexture?
+#if DEBUG
+    private var hasLoggedFallbackEnvironment = false
+    private var lastLoggedEnvironmentIdentity: ObjectIdentifier?
+#endif
 
     // dynamicUniformBuffers contains maxSimultaneousRenders uniforms buffers,
     // which we round-robin through, one per render; this is managed by switchToNextDynamicBuffer.
@@ -440,6 +515,16 @@ public class SplatRenderer {
     public func setEnvironmentMap(_ texture: MTLTexture?) throws {
         guard let texture else {
             environmentMapTexture = nil
+#if DEBUG
+            if let lastLoggedEnvironmentIdentity {
+                Self.log.debug("Cleared environment map \(lastLoggedEnvironmentIdentity); using fallback lighting")
+                self.lastLoggedEnvironmentIdentity = nil
+                hasLoggedFallbackEnvironment = true
+            } else if !hasLoggedFallbackEnvironment {
+                Self.log.debug("Environment map not provided; using fallback lighting")
+                hasLoggedFallbackEnvironment = true
+            }
+#endif
             return
         }
 
@@ -464,6 +549,16 @@ public class SplatRenderer {
         }
 
         environmentMapTexture = texture
+#if DEBUG
+        let identity = ObjectIdentifier(texture)
+        if lastLoggedEnvironmentIdentity != identity {
+            let pixelFormat = String(describing: texture.pixelFormat)
+            let size = "\(texture.width)x\(texture.height)"
+            Self.log.debug("Environment map updated to \(identity): format \(pixelFormat), size \(size), mip count \(texture.mipmapLevelCount)")
+            lastLoggedEnvironmentIdentity = identity
+        }
+        hasLoggedFallbackEnvironment = false
+#endif
     }
 
     public func setBRDFLookupTexture(_ texture: MTLTexture?) throws {
@@ -498,6 +593,11 @@ public class SplatRenderer {
     public func read(from url: URL) async throws {
         var newPoints = SplatMemoryBuffer()
         try await newPoints.read(from: try AutodetectSceneReader(url))
+#if DEBUG
+        if let diagnostics = Self.describeMaterialDiagnostics(points: newPoints.points) {
+            Self.log.info("\(diagnostics, privacy: .public)")
+        }
+#endif
         try add(newPoints.points)
     }
 

--- a/SampleApp/Scene/EnvironmentPrefilter.swift
+++ b/SampleApp/Scene/EnvironmentPrefilter.swift
@@ -70,8 +70,10 @@ final class EnvironmentPrefilter {
     private let brdfResolution: Int
 
     private var cachedBRDFLUT: MTLTexture?
+#if DEBUG
     private var luminanceScratchBuffer: MTLBuffer?
-    private var lastLoggedRevision: UInt64?
+    private var lastLoggedLuminanceRevisions: [String: UInt64] = [:]
+#endif
 
     private struct LuminanceStatistics {
         var minimum: Float
@@ -122,11 +124,28 @@ final class EnvironmentPrefilter {
         }
 
         let environmentTexture = try makeEnvironmentTexture()
+
+#if DEBUG
+        logTextureDetails(texture: snapshot.texture,
+                           label: "ARKit probe",
+                           revision: snapshot.revision)
+        if sourceTexture !== snapshot.texture {
+            logTextureDetails(texture: sourceTexture,
+                               label: "Sanitized probe view",
+                               revision: snapshot.revision)
+        }
+        logLuminanceDiagnostics(for: sourceTexture,
+                                 revision: snapshot.revision,
+                                 label: "probe")
+#endif
+
         try encodePrefilter(from: sourceTexture, to: environmentTexture)
 
-        if lastLoggedRevision != snapshot.revision {
-            logLuminanceDiagnostics(for: environmentTexture, revision: snapshot.revision)
-        }
+#if DEBUG
+        logLuminanceDiagnostics(for: environmentTexture,
+                                 revision: snapshot.revision,
+                                 label: "prefiltered")
+#endif
 
         let brdf = try makeBRDFLookupTexture()
 
@@ -282,7 +301,28 @@ final class EnvironmentPrefilter {
         }
     }
 
-    private func logLuminanceDiagnostics(for texture: MTLTexture, revision: UInt64) {
+#if DEBUG
+    private func logTextureDetails(texture: MTLTexture,
+                                   label: StaticString,
+                                   revision: UInt64) {
+        let pixelFormat = String(describing: texture.pixelFormat)
+        let textureType = String(describing: texture.textureType)
+        let usageDescription = String(describing: texture.usage)
+        let storageDescription = String(describing: texture.storageMode)
+        let size = "\(texture.width)x\(texture.height)"
+        let labelDescription = String(describing: label)
+        Self.log.debug("Environment revision \(revision) \(labelDescription): format \(pixelFormat), type \(textureType), size \(size), mip count \(texture.mipmapLevelCount), usage \(usageDescription), storage \(storageDescription)")
+    }
+
+    private func logLuminanceDiagnostics(for texture: MTLTexture,
+                                         revision: UInt64,
+                                         label: StaticString) {
+        let key = String(describing: label)
+        if let previous = lastLoggedLuminanceRevisions[key], previous == revision {
+            return
+        }
+        lastLoggedLuminanceRevisions[key] = revision
+
         let faceSize = texture.width
         let componentsPerPixel = 4
         let bytesPerPixel = componentsPerPixel * MemoryLayout<UInt16>.stride
@@ -360,15 +400,15 @@ final class EnvironmentPrefilter {
             statistics.append(LuminanceStatistics(minimum: minLum, maximum: maxLum, average: averageLum))
         }
 
-        var message = "Environment revision \(revision) luminance"
+        let labelDescription = String(describing: label)
+        var message = "Environment revision \(revision) \(labelDescription) luminance"
         for (index, stat) in statistics.enumerated() {
             let faceSummary = String(format: " F%u[min:%.3f max:%.3f avg:%.3f]", UInt32(index), stat.minimum, stat.maximum, stat.average)
             message.append(faceSummary)
         }
         Self.log.debug("\(message)")
-
-        lastLoggedRevision = revision
     }
+#endif
 }
 
 #endif // os(visionOS)


### PR DESCRIPTION
## Summary
- add debug-only logging in the environment prefilter to describe source textures and compare probe vs prefiltered luminance
- log when the renderer falls back to the built-in environment map and when a new environment cube is applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fdb43a3ea0832187fff5af5f20732e