### PR TITLE
Normalize ambient occlusion output and log fallback environment usage

### DIFF
--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -25,9 +25,19 @@ float3 safeNormalize(float3 value, float3 fallback) {
     return normalize(value);
 }
 
+/// Computes a normalized ambient occlusion factor.
+///
+/// The returned value represents the per-unit-opacity occlusion contribution, so
+/// that the final shading remains proportional to a single power of opacity even
+/// after tone mapping.
 half computeAmbientOcclusion(half opacity) {
     half clampedOpacity = clamp(opacity, half(0), half(1));
-    return half(1) - half(fast::exp(-float(clampedOpacity)));
+    float occlusion = 1.0f - fast::exp(-float(clampedOpacity));
+    if (clampedOpacity <= half(1e-3f)) {
+        return half(0);
+    }
+    float normalized = occlusion / float(clampedOpacity);
+    return half(min(1.0f, normalized));
 }
 
 float3 sampleDiffuseIrradiance(texturecube<half> environmentMap,

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -355,6 +355,7 @@ public class SplatRenderer {
     private let brdfSamplerState: MTLSamplerState
     private var environmentMapTexture: MTLTexture?
     private var brdfLookupTexture: MTLTexture?
+    private var didLogFallbackEnvironmentMapUsage = false
 
     // dynamicUniformBuffers contains maxSimultaneousRenders uniforms buffers,
     // which we round-robin through, one per render; this is managed by switchToNextDynamicBuffer.
@@ -440,6 +441,7 @@ public class SplatRenderer {
     public func setEnvironmentMap(_ texture: MTLTexture?) throws {
         guard let texture else {
             environmentMapTexture = nil
+            didLogFallbackEnvironmentMapUsage = false
             return
         }
 
@@ -464,6 +466,7 @@ public class SplatRenderer {
         }
 
         environmentMapTexture = texture
+        didLogFallbackEnvironmentMapUsage = false
     }
 
     public func setBRDFLookupTexture(_ texture: MTLTexture?) throws {
@@ -666,6 +669,11 @@ public class SplatRenderer {
     }
 
     private func bindMaterialResources(to renderEncoder: MTLRenderCommandEncoder) {
+        let isUsingFallbackEnvironment = environmentMapTexture == nil
+        if isUsingFallbackEnvironment && !didLogFallbackEnvironmentMapUsage {
+            Self.log.warning("Using fallback 1x1 environment map; check environment probe configuration")
+            didLogFallbackEnvironmentMapUsage = true
+        }
         let environmentTexture = environmentMapTexture ?? fallbackEnvironmentMap
         let brdfTexture = brdfLookupTexture ?? fallbackBRDFLUT
         renderEncoder.setFragmentTexture(environmentTexture, index: TextureIndex.environment.rawValue)


### PR DESCRIPTION
## Summary
- normalize the Metal ambient occlusion helper to return a per-opacity factor and document the new behavior
- warn when the renderer binds the fallback environment map so debugging missing probes is easier

## Testing
- swift build *(fails: unavailable Apple-only frameworks in Linux CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe78f8d0dc83218a810e1de3b4b7c6