### PR TITLE
Add debug view configuration plumbing

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -3,9 +3,9 @@
 
 // Debug visualization selector:
 // 0: coverage (alpha), 1: albedo, 2: normal, 3: roughness, 4: metallic, 5: AO, 6: depth, 7: shaded (default)
-#ifndef DEBUG_VIEW
-#define DEBUG_VIEW 1
-#endif
+constant uint DEBUG_VIEW [[function_constant(0)]];
+constant bool DEBUG_VIEW_IS_DEFINED = is_function_constant_defined(DEBUG_VIEW);
+constant uint DEBUG_VIEW_VALUE = DEBUG_VIEW_IS_DEFINED ? DEBUG_VIEW : 1;
 
 // ---- Normal decoding controls (tweak and rebuild) ----
 #ifndef NORMAL_STORAGE_01
@@ -187,53 +187,48 @@ inline half4 resolveFragmentValues(FragmentValues fragmentValues,
     half3 normal_raw = normalize(normal);
     half3 normal_dec = decodeNormal(normal);
 
-#if DEBUG_VIEW == 1
-    // Albedo
-    return half4(albedo, 1);
-#elif DEBUG_VIEW == 2
-    // Normal (visualized as 0..1)
-    return half4(normalize(normal) * 0.5h + 0.5h, 1);
-#elif DEBUG_VIEW == 3
-    // Roughness
-    return half4(roughness, roughness, roughness, 1);
-#elif DEBUG_VIEW == 4
-    // Metallic
-    return half4(metallic, metallic, metallic, 1);
-#elif DEBUG_VIEW == 5
-    // Ambient occlusion
-    return half4(ao, ao, ao, 1);
-#elif DEBUG_VIEW == 21
-    // Albedo visualized after sRGB->linear conversion (diagnostic)
-    return half4(srgbToLinear(albedo), 1);
-#elif DEBUG_VIEW == 22
-    // Roughness (duplicate of 3, kept for explicit material sweep)
-    return half4(roughness, roughness, roughness, 1);
-#elif DEBUG_VIEW == 23
-    // Metallic (duplicate of 4, kept for explicit material sweep)
-    return half4(metallic, metallic, metallic, 1);
-#elif DEBUG_VIEW == 24
-    // Normal (duplicate of 2, kept for explicit material sweep)
-    return half4(normal_dec * 0.5h + 0.5h, 1);
-#elif DEBUG_VIEW == 25
-    // Raw-as-is normal visualization (before decode)
-    return half4(normal_raw * 0.5h + 0.5h, 1);
-#elif DEBUG_VIEW == 26
-    // Difference heatmap between decoded and raw normals
-    {
+    if (DEBUG_VIEW_VALUE == 1) {
+        // Albedo
+        return half4(albedo, 1);
+    } else if (DEBUG_VIEW_VALUE == 2) {
+        // Normal (visualized as 0..1)
+        return half4(normalize(normal) * 0.5h + 0.5h, 1);
+    } else if (DEBUG_VIEW_VALUE == 3) {
+        // Roughness
+        return half4(roughness, roughness, roughness, 1);
+    } else if (DEBUG_VIEW_VALUE == 4) {
+        // Metallic
+        return half4(metallic, metallic, metallic, 1);
+    } else if (DEBUG_VIEW_VALUE == 5) {
+        // Ambient occlusion
+        return half4(ao, ao, ao, 1);
+    } else if (DEBUG_VIEW_VALUE == 21) {
+        // Albedo visualized after sRGB->linear conversion (diagnostic)
+        return half4(srgbToLinear(albedo), 1);
+    } else if (DEBUG_VIEW_VALUE == 22) {
+        // Roughness (duplicate of 3, kept for explicit material sweep)
+        return half4(roughness, roughness, roughness, 1);
+    } else if (DEBUG_VIEW_VALUE == 23) {
+        // Metallic (duplicate of 4, kept for explicit material sweep)
+        return half4(metallic, metallic, metallic, 1);
+    } else if (DEBUG_VIEW_VALUE == 24) {
+        // Normal (duplicate of 2, kept for explicit material sweep)
+        return half4(normal_dec * 0.5h + 0.5h, 1);
+    } else if (DEBUG_VIEW_VALUE == 25) {
+        // Raw-as-is normal visualization (before decode)
+        return half4(normal_raw * 0.5h + 0.5h, 1);
+    } else if (DEBUG_VIEW_VALUE == 26) {
+        // Difference heatmap between decoded and raw normals
         half3 diff = abs(normal_dec - normal_raw);
         return half4(diff, 1);
-    }
-#elif DEBUG_VIEW == 27
-    // N·V comparison: R=using decoded normal, G=using raw normal
-    {
+    } else if (DEBUG_VIEW_VALUE == 27) {
+        // N·V comparison: R=using decoded normal, G=using raw normal
         half3 V = normalize(viewDir);
         half ndv_dec = saturate(dot(normal_dec, V));
         half ndv_raw = saturate(dot(normal_raw, V));
         return half4(ndv_dec, ndv_raw, 0.0h, 1);
-    }
-#elif DEBUG_VIEW == 8
-    // Shaded result with AO forced to 1 (tests if AO is zeroing energy)
-    {
+    } else if (DEBUG_VIEW_VALUE == 8) {
+        // Shaded result with AO forced to 1 (tests if AO is zeroing energy)
         half3 shaded = shadeGaussian(albedo,
                                      metallic,
                                      roughness,
@@ -245,56 +240,47 @@ inline half4 resolveFragmentValues(FragmentValues fragmentValues,
                                      environmentSampler,
                                      brdfSampler);
         return half4(shaded * accumulatedAlpha, accumulatedAlpha);
-    }
-#elif DEBUG_VIEW == 9
-    // Direct environment reflection sample (tests env binding/indices)
-    {
+    } else if (DEBUG_VIEW_VALUE == 9) {
+        // Direct environment reflection sample (tests env binding/indices)
         half3 N = normalize(normal);
         half3 V = normalize(viewDir);
         half3 R = reflect(-V, N);
         half3 env = environmentMap.sample(environmentSampler, float3(R)).rgb;
         return half4(env, 1);
-    }
-#elif DEBUG_VIEW == 10
-    // N·V visualization (tests geometry/normal-view relationship)
-    {
+    } else if (DEBUG_VIEW_VALUE == 10) {
+        // N·V visualization (tests geometry/normal-view relationship)
         half3 N = normalize(normal);
         half3 V = normalize(viewDir);
         half ndv = saturate(dot(N, V));
         return half4(ndv, ndv, ndv, 1);
-    }
-#elif DEBUG_VIEW == 12
-    // Simple Lambert with a fixed key light (no env/BRDF) to prove shading path works
-    {
+    } else if (DEBUG_VIEW_VALUE == 12) {
+        // Simple Lambert with a fixed key light (no env/BRDF) to prove shading path works
         half3 N = normalize(normal);
         half3 L = normalize(half3(0.4h, 0.8h, 0.4h));
         half ndl = saturate(dot(N, L));
         half3 lit = albedo * ndl;
         return half4(lit * accumulatedAlpha, accumulatedAlpha);
-    }
-#elif DEBUG_VIEW == 13
-    // BRDF LUT debug: show LUT sample at center to validate BRDF binding
-    {
+    } else if (DEBUG_VIEW_VALUE == 13) {
+        // BRDF LUT debug: show LUT sample at center to validate BRDF binding
         half2 l = brdfLUT.sample(brdfSampler, float2(0.5, 0.5)).rg;
         return half4(l.x, l.y, 0, 1);
+    } else if (DEBUG_VIEW_VALUE == 7) {
+        // Shaded result (uses environment)
+        half3 shaded = shadeGaussian(albedo,
+                                     metallic,
+                                     roughness,
+                                     normal_dec,
+                                     viewDir,
+                                     ao,
+                                     environmentMap,
+                                     brdfLUT,
+                                     environmentSampler,
+                                     brdfSampler);
+        return half4(shaded * accumulatedAlpha, accumulatedAlpha);
+    } else {
+        // Coverage and depth handled in postprocess
+        return half4(0);
     }
-#elif DEBUG_VIEW == 7
-    // Shaded result (uses environment)
-    half3 shaded = shadeGaussian(albedo,
-                                 metallic,
-                                 roughness,
-                                 normal_dec,
-                                 viewDir,
-                                 ao,
-                                 environmentMap,
-                                 brdfLUT,
-                                 environmentSampler,
-                                 brdfSampler);
-    return half4(shaded * accumulatedAlpha, accumulatedAlpha);
-#else
-    // Coverage and depth handled in postprocess
-    return half4(0);
-#endif
 }
 
 fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[imageblock_data]],
@@ -307,20 +293,18 @@ fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[i
         half accumulatedAlpha = fragmentValues.viewAlpha.w;
         out.depth = (accumulatedAlpha == 0) ? 0 : fragmentValues.depth / accumulatedAlpha;
 
-#if DEBUG_VIEW == 0
-        // Coverage view (grayscale alpha)
-        half a = clamp(accumulatedAlpha, 0.0h, 1.0h);
-        out.color = half4(a, a, a, 1);
-        return out;
-#elif DEBUG_VIEW == 6
-        // Depth visualization mapped to [0,1]
-        half d = half(out.depth);
-        out.color = half4(d, d, d, 1);
-        return out;
-#elif DEBUG_VIEW == 11
-        // Direct environment sample (panorama from screen UV -> direction), ignores accumulation
-        {
-            // Map NDC to [0,1]
+        if (DEBUG_VIEW_VALUE == 0) {
+            // Coverage view (grayscale alpha)
+            half a = clamp(accumulatedAlpha, 0.0h, 1.0h);
+            out.color = half4(a, a, a, 1);
+            return out;
+        } else if (DEBUG_VIEW_VALUE == 6) {
+            // Depth visualization mapped to [0,1]
+            half d = half(out.depth);
+            out.color = half4(d, d, d, 1);
+            return out;
+        } else if (DEBUG_VIEW_VALUE == 11) {
+            // Direct environment sample (panorama from screen UV -> direction), ignores accumulation
             float2 uv = float2((fragmentValues.viewAlpha.x + 1.0f) * 0.5f, (fragmentValues.viewAlpha.y + 1.0f) * 0.5f);
             // Equirectangular-like mapping to direction (yaw=pitch)
             float phi = (uv.x * 2.0f - 1.0f) * M_PI_F;        // -pi..pi
@@ -329,33 +313,28 @@ fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[i
             half3 env = environmentMap.sample(environmentSampler, dir).rgb;
             out.color = half4(env, 1);
             return out;
-        }
-#elif DEBUG_VIEW == 14
-        // Env sample at fixed direction, forced LOD 0
-        {
+        } else if (DEBUG_VIEW_VALUE == 14) {
+            // Env sample at fixed direction, forced LOD 0
             float3 dir = float3(0.0, 1.0, 0.0);
             half3 env = environmentMap.sample(environmentSampler, dir, level(0.0)).rgb;
             out.color = half4(env, 1);
             return out;
-        }
-#elif DEBUG_VIEW == 15
-        // Env sample at fixed direction, largest mip (very blurred)
-        {
+        } else if (DEBUG_VIEW_VALUE == 15) {
+            // Env sample at fixed direction, largest mip (very blurred)
             float3 dir = float3(0.0, 1.0, 0.0);
             float maxLevel = log2((float)environmentMap.get_width());
             half3 env = environmentMap.sample(environmentSampler, dir, level(maxLevel)).rgb;
             out.color = half4(env, 1);
             return out;
+        } else {
+            // Use resolveFragmentValues for attribute views or shaded output
+            out.color = resolveFragmentValues(fragmentValues,
+                                              environmentMap,
+                                              brdfLUT,
+                                              environmentSampler,
+                                              brdfSampler);
+            return out;
         }
-#else
-        // Use resolveFragmentValues for attribute views or shaded output
-        out.color = resolveFragmentValues(fragmentValues,
-                                          environmentMap,
-                                          brdfLUT,
-                                          environmentSampler,
-                                          brdfSampler);
-        return out;
-#endif
     }
 }
 
@@ -366,19 +345,19 @@ fragment half4 postprocessFragmentShaderNoDepth(FragmentValues fragmentValues [[
                                                sampler brdfSampler [[sampler(1)]]) {
     {
         // No depth resolve path — choose debug view or shaded like the main postprocess
-#if DEBUG_VIEW == 0
-        // Coverage is not available without depth resolve; show AO as a proxy
-        half a = fragmentValues.ambientOcclusion.x;
-        return half4(a, a, a, 1);
-#elif DEBUG_VIEW == 6
-        // No depth resolve here; return black
-        return half4(0,0,0,1);
-#else
-        return resolveFragmentValues(fragmentValues,
-                                     environmentMap,
-                                     brdfLUT,
-                                     environmentSampler,
-                                     brdfSampler);
-#endif
+        if (DEBUG_VIEW_VALUE == 0) {
+            // Coverage is not available without depth resolve; show AO as a proxy
+            half a = fragmentValues.ambientOcclusion.x;
+            return half4(a, a, a, 1);
+        } else if (DEBUG_VIEW_VALUE == 6) {
+            // No depth resolve here; return black
+            return half4(0,0,0,1);
+        } else {
+            return resolveFragmentValues(fragmentValues,
+                                         environmentMap,
+                                         brdfLUT,
+                                         environmentSampler,
+                                         brdfSampler);
+        }
     }
 }

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -38,6 +38,32 @@ public class SplatRenderer {
     private static let signposter = OSSignposter(logger: log)
 #endif
 
+    public enum DebugViewMode: UInt, CaseIterable {
+        case coverage = 0
+        case albedo = 1
+        case normal = 2
+        case roughness = 3
+        case metallic = 4
+        case ambientOcclusion = 5
+        case depth = 6
+        case shaded = 7
+        case shadedAmbientOcclusionUnity = 8
+        case environmentReflection = 9
+        case normalViewRelationship = 10
+        case environmentPanorama = 11
+        case lambert = 12
+        case brdfLookup = 13
+        case environmentFixedLod0 = 14
+        case environmentFixedMaxLod = 15
+        case albedoLinear = 21
+        case roughnessSweep = 22
+        case metallicSweep = 23
+        case normalSweep = 24
+        case normalRaw = 25
+        case normalDifference = 26
+        case normalDotComparison = 27
+    }
+
     public enum Error: Swift.Error, LocalizedError {
         case invalidMaterialResource(resource: String, reason: String)
 
@@ -318,6 +344,13 @@ public class SplatRenderer {
      */
     public var highQualityDepth: Bool = true
 
+    public var debugViewMode: DebugViewMode = .albedo {
+        didSet {
+            guard oldValue != debugViewMode else { return }
+            resetPipelineStates()
+        }
+    }
+
     private var writeDepth: Bool {
         depthFormat != .invalid
     }
@@ -516,6 +549,13 @@ public class SplatRenderer {
         postprocessDepthState = nil
     }
 
+    private func makeDebugViewFunction(named name: String) -> MTLFunction {
+        var value = UInt32(debugViewMode.rawValue)
+        let constants = MTLFunctionConstantValues()
+        constants.setConstantValue(&value, type: .uint, index: 0)
+        return library.makeRequiredFunction(name: name, constantValues: constants)
+    }
+
     private func buildSingleStagePipelineStatesIfNeeded() throws {
         guard singleStagePipelineState == nil else { return }
 
@@ -591,7 +631,7 @@ public class SplatRenderer {
 
         pipelineDescriptor.label = "DrawSplatPipeline"
         pipelineDescriptor.vertexFunction = library.makeRequiredFunction(name: "multiStageSplatVertexShader")
-        pipelineDescriptor.fragmentFunction = library.makeRequiredFunction(name: "multiStageSplatFragmentShader")
+        pipelineDescriptor.fragmentFunction = makeDebugViewFunction(named: "multiStageSplatFragmentShader")
 
         pipelineDescriptor.rasterSampleCount = sampleCount
 
@@ -622,8 +662,8 @@ public class SplatRenderer {
             library.makeRequiredFunction(name: "postprocessVertexShader")
         pipelineDescriptor.fragmentFunction =
             writeDepth
-            ? library.makeRequiredFunction(name: "postprocessFragmentShader")
-            : library.makeRequiredFunction(name: "postprocessFragmentShaderNoDepth")
+            ? makeDebugViewFunction(named: "postprocessFragmentShader")
+            : makeDebugViewFunction(named: "postprocessFragmentShaderNoDepth")
 
         pipelineDescriptor.colorAttachments[0]!.pixelFormat = colorFormat
         pipelineDescriptor.depthAttachmentPixelFormat = depthFormat
@@ -1238,5 +1278,13 @@ private extension MTLLibrary {
             fatalError("Unable to load required shader function: \"\(name)\"")
         }
         return result
+    }
+
+    func makeRequiredFunction(name: String, constantValues: MTLFunctionConstantValues) -> MTLFunction {
+        do {
+            return try makeFunction(name: name, constantValues: constantValues)
+        } catch {
+            fatalError("Unable to load required shader function: \"\(name)\" with constants: \(error)")
+        }
     }
 }

--- a/SampleApp/App/SampleApp.swift
+++ b/SampleApp/App/SampleApp.swift
@@ -5,15 +5,19 @@ import SwiftUI
 
 @main
 struct SampleApp: App {
+    @StateObject private var rendererSettings = RendererSettings()
+
     var body: some Scene {
         WindowGroup("MetalSplatter Sample App", id: "main") {
             ContentView()
+                .environmentObject(rendererSettings)
         }
 
 #if os(macOS)
         WindowGroup(for: ModelIdentifier.self) { modelIdentifier in
             MetalKitSceneView(modelIdentifier: modelIdentifier.wrappedValue)
                 .navigationTitle(modelIdentifier.wrappedValue?.description ?? "No Model")
+                .environmentObject(rendererSettings)
         }
 #endif // os(macOS)
 
@@ -21,6 +25,7 @@ struct SampleApp: App {
         ImmersiveSpace(for: ModelIdentifier.self) { modelIdentifier in
             CompositorLayer(configuration: ContentStageConfiguration()) { layerRenderer in
                 let renderer = VisionSceneRenderer(layerRenderer)
+                renderer.bindRendererSettings(rendererSettings)
                 Task {
                     do {
                         try await renderer.load(modelIdentifier.wrappedValue)

--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -28,7 +28,8 @@
 		61791E132B416DD700302B57 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E112B416DCF00302B57 /* Constants.swift */; };
 		61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
 		617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
-		617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
+                617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
+                61F2B3A12F5C123400A1A1A1 /* RendererSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,7 +52,8 @@
                 61A1AA002B7C000100A1AA00 /* EnvironmentProbeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProbeManager.swift; sourceTree = "<group>"; };
                 61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentPrefilter.swift; sourceTree = "<group>"; };
                 61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = EnvironmentPrefilter.metal; sourceTree = "<group>"; };
-		617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+                61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererSettings.swift; sourceTree = "<group>"; };
+                617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +95,7 @@
                                 61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */,
                                 61791E142B42294700302B57 /* MetalKitSceneView.swift */,
                                 61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
+                                61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */,
                         );
                         path = Scene;
                         sourceTree = "<group>";
@@ -241,12 +244,13 @@
                                 61791DE02B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift in Sources */,
                                 147AFBD02E33ED730052B2AD /* CameraController.swift in Sources */,
                                 147AFBD12E33ED730052B2AD /* InteractiveMTKView.swift in Sources */,
-				61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
-				61791DCF2B41544300302B57 /* Assets.xcassets in Sources */,
-				61791E132B416DD700302B57 /* Constants.swift in Sources */,
-				61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */,
-				610347DC2B46875A00693CE3 /* ContentStageConfiguration.swift in Sources */,
-			);
+                                61791DE82B4154FB00302B57 /* ModelRenderer.swift in Sources */,
+                                61791DCF2B41544300302B57 /* Assets.xcassets in Sources */,
+                                61791E132B416DD700302B57 /* Constants.swift in Sources */,
+                                61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */,
+                                610347DC2B46875A00693CE3 /* ContentStageConfiguration.swift in Sources */,
+                                61F2B3A12F5C123400A1A1A1 /* RendererSettings.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @State private var isPickingFile = false
+    @EnvironmentObject private var rendererSettings: RendererSettings
 
 #if os(macOS)
     @Environment(\.openWindow) private var openWindow
@@ -42,6 +43,7 @@ struct ContentView: View {
                 .navigationDestination(for: ModelIdentifier.self) { modelIdentifier in
                     MetalKitSceneView(modelIdentifier: modelIdentifier)
                         .navigationTitle(modelIdentifier.description)
+                        .environmentObject(rendererSettings)
                 }
         }
 #endif // os(iOS)
@@ -55,6 +57,14 @@ struct ContentView: View {
             Text("MetalSplatter SampleApp")
 
             Spacer()
+
+            Picker("Debug View", selection: $rendererSettings.debugViewMode) {
+                ForEach(rendererSettings.primaryDebugModes, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
 
             Button("Read Scene File") {
                 isPickingFile = true

--- a/SampleApp/Scene/MetalKitSceneRenderer.swift
+++ b/SampleApp/Scene/MetalKitSceneRenderer.swift
@@ -31,6 +31,13 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
 
     var drawableSize: CGSize = .zero
 
+    var debugViewMode: SplatRenderer.DebugViewMode = .albedo {
+        didSet {
+            guard oldValue != debugViewMode else { return }
+            applyDebugViewMode()
+        }
+    }
+
     init?(_ metalKitView: MTKView, camera: CameraController? = nil) {
         self.device = metalKitView.device!
         guard let queue = self.device.makeCommandQueue() else { return nil }
@@ -61,6 +68,7 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
                                                 maxViewCount: 1,
                                                 maxSimultaneousRenders: Constants.maxSimultaneousRenders)
             try await splat.read(from: url)
+            splat.debugViewMode = debugViewMode
             modelRenderer = splat
         case .sampleBox:
             modelRenderer = try! await SampleBoxRenderer(device: device,
@@ -159,6 +167,11 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
 
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         drawableSize = size
+    }
+
+    private func applyDebugViewMode() {
+        guard let splat = modelRenderer as? SplatRenderer else { return }
+        splat.debugViewMode = debugViewMode
     }
 }
 

--- a/SampleApp/Scene/MetalKitSceneView.swift
+++ b/SampleApp/Scene/MetalKitSceneView.swift
@@ -11,6 +11,7 @@ private typealias ViewRepresentable = UIViewRepresentable
 
 struct MetalKitSceneView: ViewRepresentable {
     var modelIdentifier: ModelIdentifier?
+    @EnvironmentObject private var rendererSettings: RendererSettings
 
     class Coordinator {
         var renderer: MetalKitSceneRenderer?
@@ -54,6 +55,8 @@ struct MetalKitSceneView: ViewRepresentable {
         coordinator.renderer = renderer
         metalKitView.delegate = renderer
 
+        renderer?.debugViewMode = rendererSettings.debugViewMode
+
         Task {
             do {
                 try await renderer?.load(modelIdentifier)
@@ -77,6 +80,7 @@ struct MetalKitSceneView: ViewRepresentable {
 
     private func updateView(_ coordinator: Coordinator) {
         guard let renderer = coordinator.renderer else { return }
+        renderer.debugViewMode = rendererSettings.debugViewMode
         Task {
             do {
                 try await renderer.load(modelIdentifier)

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -1,0 +1,69 @@
+import Foundation
+import MetalSplatter
+
+final class RendererSettings: ObservableObject {
+    @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo
+    let primaryDebugModes: [SplatRenderer.DebugViewMode] = [
+        .shaded,
+        .albedo,
+        .normal,
+        .roughness,
+        .metallic,
+        .ambientOcclusion,
+        .depth,
+        .coverage
+    ]
+}
+
+extension SplatRenderer.DebugViewMode {
+    var displayName: String {
+        switch self {
+        case .coverage:
+            return "Coverage"
+        case .albedo:
+            return "Albedo"
+        case .normal:
+            return "Normal"
+        case .roughness:
+            return "Roughness"
+        case .metallic:
+            return "Metallic"
+        case .ambientOcclusion:
+            return "AO"
+        case .depth:
+            return "Depth"
+        case .shaded:
+            return "Shaded"
+        case .shadedAmbientOcclusionUnity:
+            return "Shaded (AO=1)"
+        case .environmentReflection:
+            return "Reflection"
+        case .normalViewRelationship:
+            return "N·V"
+        case .environmentPanorama:
+            return "Env Panorama"
+        case .lambert:
+            return "Lambert"
+        case .brdfLookup:
+            return "BRDF LUT"
+        case .environmentFixedLod0:
+            return "Env LOD0"
+        case .environmentFixedMaxLod:
+            return "Env Max LOD"
+        case .albedoLinear:
+            return "Albedo (Linear)"
+        case .roughnessSweep:
+            return "Roughness (Alt)"
+        case .metallicSweep:
+            return "Metallic (Alt)"
+        case .normalSweep:
+            return "Normal (Alt)"
+        case .normalRaw:
+            return "Normal Raw"
+        case .normalDifference:
+            return "Normal Δ"
+        case .normalDotComparison:
+            return "N·V Compare"
+        }
+    }
+}

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -1,6 +1,7 @@
 #if os(visionOS)
 
 import ARKit
+import Combine
 import CompositorServices
 import Foundation
 import Metal
@@ -77,6 +78,10 @@ class VisionSceneRenderer {
     private var didAutoCapture: Bool = false
     private var captureNextFrame: Bool = false
     private var lastBrightnessProbeFrame: UInt64 = 0
+    private var rendererSettingsCancellable: AnyCancellable?
+    private var debugViewModeStorage: SplatRenderer.DebugViewMode = .albedo
+    private let debugViewModeLock = NSLock()
+    private var debugViewModeNeedsApply = false
 
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
@@ -116,6 +121,7 @@ class VisionSceneRenderer {
                                           maxViewCount: layerRenderer.properties.viewCount,
                                           maxSimultaneousRenders: Constants.maxSimultaneousRenders)
             try await splat.read(from: url)
+            splat.debugViewMode = debugViewMode
             modelRenderer = splat
             if environmentPrefilterResult != nil {
                 environmentResourcesDirty = true
@@ -416,10 +422,51 @@ class VisionSceneRenderer {
                 continue
             } else {
                 autoreleasepool {
+                    self.applyDebugViewModeIfNeeded()
                     self.renderFrame()
                 }
             }
         }
+    }
+
+    func bindRendererSettings(_ settings: RendererSettings) {
+        debugViewMode = settings.debugViewMode
+        rendererSettingsCancellable = settings.$debugViewMode
+            .sink { [weak self] mode in
+                self?.debugViewMode = mode
+            }
+    }
+
+    private var debugViewMode: SplatRenderer.DebugViewMode {
+        get {
+            debugViewModeLock.lock()
+            defer { debugViewModeLock.unlock() }
+            return debugViewModeStorage
+        }
+        set {
+            debugViewModeLock.lock()
+            let didChange = debugViewModeStorage != newValue
+            debugViewModeStorage = newValue
+            if didChange {
+                debugViewModeNeedsApply = true
+            }
+            debugViewModeLock.unlock()
+        }
+    }
+
+    private func applyDebugViewModeIfNeeded() {
+        let mode: SplatRenderer.DebugViewMode?
+        debugViewModeLock.lock()
+        if debugViewModeNeedsApply {
+            debugViewModeNeedsApply = false
+            mode = debugViewModeStorage
+        } else {
+            mode = nil
+        }
+        debugViewModeLock.unlock()
+
+        guard let mode, let splat = modelRenderer as? SplatRenderer else { return }
+        splat.debugViewMode = mode
     }
 
     private func updateEnvironmentProbeIfNeeded() {


### PR DESCRIPTION
## Summary
- expose the multi-stage debug selector as a function constant and plumb the choice through `SplatRenderer`
- add a shared `RendererSettings` observable object and surface a debug-view picker in the sample app UI
- propagate the selected debug mode to scene renderers and ensure the new settings file is part of the project

## Testing
- `swift build` *(fails: missing Apple-only modules such as os/Metal when building on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68ff9affe23c8321be387e9891c7f30f