### PR TITLE
Fix hand anchor caching to support two-hand manipulation

### DIFF
--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -137,8 +137,14 @@ class VisionSceneRenderer {
         handUpdateTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
             for await update in self.handTracking.anchorUpdates {
-                let anchor = update.anchor
-                self.cacheHandAnchors([anchor])
+                switch update.event {
+                case .added, .updated:
+                    self.cacheHandAnchors([update.anchor])
+                case .removed:
+                    self.removeCachedHandState(for: update.anchor.chirality)
+                @unknown default:
+                    break
+                }
             }
         }
     }
@@ -499,10 +505,12 @@ class VisionSceneRenderer {
         for (chirality, state) in updates {
             cachedHandStates[chirality] = state
         }
-        let missing = Set(cachedHandStates.keys).subtracting(updates.keys)
-        for chirality in missing {
-            cachedHandStates.removeValue(forKey: chirality)
-        }
+        handStateLock.unlock()
+    }
+
+    private func removeCachedHandState(for chirality: HandAnchor.Chirality) {
+        handStateLock.lock()
+        cachedHandStates.removeValue(forKey: chirality)
         handStateLock.unlock()
     }
 


### PR DESCRIPTION
## Summary
- keep cached hand states for the opposite hand when only one anchor updates
- remove cached hand states only when a hand anchor removal event is received

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffb1a067e08321a8b98019f0733667