### PR TITLE
Handle GIR raw albedo exports

### DIFF
--- a/SplatIO/Sources/SplatPLYSceneReader.swift
+++ b/SplatIO/Sources/SplatPLYSceneReader.swift
@@ -136,7 +136,7 @@ private struct ElementInputMapping {
     }
 
     enum Albedo {
-        case float32(SIMD3<Int>)
+        case float32(SIMD3<Int>, girRaw: Bool)
         case uint8(SIMD3<Int>)
     }
 
@@ -237,7 +237,15 @@ private struct ElementInputMapping {
         if let albedoRFloatPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoR, type: .float32),
            let albedoGFloatPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoG, type: .float32),
            let albedoBFloatPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoB, type: .float32) {
-            albedoPropertyIndices = .float32(SIMD3(albedoRFloatPropertyIndex, albedoGFloatPropertyIndex, albedoBFloatPropertyIndex))
+            let indices = SIMD3(albedoRFloatPropertyIndex, albedoGFloatPropertyIndex, albedoBFloatPropertyIndex)
+            let propertyNames: Set<String> = Set([
+                headerElement.properties[albedoRFloatPropertyIndex].name,
+                headerElement.properties[albedoGFloatPropertyIndex].name,
+                headerElement.properties[albedoBFloatPropertyIndex].name
+            ])
+            let girRawNames: Set<String> = ["albedo_r", "albedo_g", "albedo_b"]
+            let isGIRRaw = propertyNames == girRawNames
+            albedoPropertyIndices = .float32(indices, girRaw: isGIRRaw)
         } else if let albedoRUIntPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoR, type: .uint8),
                     let albedoGUIntPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoG, type: .uint8),
                     let albedoBUIntPropertyIndex = try headerElement.index(forOptionalPropertyNamed: SplatPLYConstants.PropertyName.albedoB, type: .uint8) {
@@ -323,13 +331,17 @@ private struct ElementInputMapping {
 
         if let albedoPropertyIndices {
             switch albedoPropertyIndices {
-            case .float32(let propertyIndices):
+            case .float32(let propertyIndices, girRaw: let isGIRRaw):
                 let values = try element.float32Vector(forPropertyIndices: propertyIndices)
-                let maxComponent = max(values.x, max(values.y, values.z))
-                if maxComponent > ElementInputMapping.float256Threshold {
-                    result.setAlbedo(.linearFloat256(values))
+                if isGIRRaw {
+                    result.setAlbedo(.girRawLinearFloat(values))
                 } else {
-                    result.setAlbedo(.linearFloat(values))
+                    let maxComponent = max(values.x, max(values.y, values.z))
+                    if maxComponent > ElementInputMapping.float256Threshold {
+                        result.setAlbedo(.linearFloat256(values))
+                    } else {
+                        result.setAlbedo(.linearFloat(values))
+                    }
                 }
             case .uint8(let propertyIndices):
                 let values = try element.uint8Vector(forPropertyIndices: propertyIndices)

--- a/SplatIO/Sources/SplatScenePoint.swift
+++ b/SplatIO/Sources/SplatScenePoint.swift
@@ -152,6 +152,7 @@ public struct SplatScenePoint {
     }
 
     public enum AlbedoInput {
+        case girRawLinearFloat(SIMD3<Float>)
         case linearFloat(SIMD3<Float>)
         case linearFloat256(SIMD3<Float>)
         case linearUInt8(SIMD3<UInt8>)
@@ -207,6 +208,9 @@ public struct SplatScenePoint {
 
     public mutating func setAlbedo(_ input: AlbedoInput) {
         switch input {
+        case .girRawLinearFloat(let values):
+            let converted = values + SIMD3<Float>(repeating: 0.5)
+            albedo = converted.clamped01()
         case .linearFloat(let values):
             albedo = values.clamped01()
         case .linearFloat256(let values):

--- a/SplatIO/Tests/SplatIOTests.swift
+++ b/SplatIO/Tests/SplatIOTests.swift
@@ -195,13 +195,57 @@ final class SplatIOTests: XCTestCase {
         property float rot_1
         property float rot_2
         property float rot_3
+        property float base_color_r
+        property float base_color_g
+        property float base_color_b
+        property float metallic
+        property float roughness
+        end_header
+        0 0 0 0 0 1 0 0 0 0 1 1 1 1 0 0 0 0.25 0.5 0.75 0.2 0.8
+        """
+
+        let points = try readPoints(fromASCII: ascii)
+        XCTAssertEqual(points.count, 1)
+        let point = try XCTUnwrap(points.first)
+        XCTAssertEqual(point.albedo.x, 0.25, accuracy: 1e-5)
+        XCTAssertEqual(point.albedo.y, 0.5, accuracy: 1e-5)
+        XCTAssertEqual(point.albedo.z, 0.75, accuracy: 1e-5)
+        XCTAssertEqual(point.metallic, 0.2, accuracy: 1e-5)
+        XCTAssertEqual(point.roughness, 0.8, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.x, 0.0, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.y, 0.0, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.z, 1.0, accuracy: 1e-5)
+    }
+
+    func testPLYMaterialFloat32GIRRaw() throws {
+        let ascii = """
+        ply
+        format ascii 1.0
+        element vertex 1
+        property float x
+        property float y
+        property float z
+        property float nx
+        property float ny
+        property float nz
+        property float f_dc_0
+        property float f_dc_1
+        property float f_dc_2
+        property float opacity
+        property float scale_0
+        property float scale_1
+        property float scale_2
+        property float rot_0
+        property float rot_1
+        property float rot_2
+        property float rot_3
         property float albedo_r
         property float albedo_g
         property float albedo_b
         property float metallic
         property float roughness
         end_header
-        0 0 0 0 0 1 0 0 0 0 1 1 1 1 0 0 0 0.25 0.5 0.75 0.2 0.8
+        0 0 0 0 0 1 0 0 0 0 1 1 1 1 0 0 0 -0.25 0 0.25 0.2 0.8
         """
 
         let points = try readPoints(fromASCII: ascii)
@@ -239,9 +283,9 @@ final class SplatIOTests: XCTestCase {
         property float rot_1
         property float rot_2
         property float rot_3
-        property float albedo_r
-        property float albedo_g
-        property float albedo_b
+        property float base_color_r
+        property float base_color_g
+        property float base_color_b
         property float metallic
         property float roughness
         end_header


### PR DESCRIPTION
## Summary
- add a GIR raw albedo conversion path that recenters values before clamping
- mark albedo_r/g/b properties as GIR raw inside the PLY reader so the new conversion is used
- extend the SplatIO tests to cover GIR raw exports while keeping existing base color checks

## Testing
- `swift test` *(fails: missing Apple-specific Metal module in Linux toolchain)*
- `swift run SplatConverter --describe --start 0 --count 3 SplatIO/TestData/test-splat.3-points-from-train.ply` *(fails: missing Apple-specific Metal and os modules in Linux toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb0ef969c832181ebf835b0912360