### PR TITLE
Stop idle rotation when hands are idle

### DIFF
--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -368,10 +368,6 @@ class VisionSceneRenderer {
         let now = Date()
         defer { lastRotationUpdateTimestamp = now }
 
-        guard let lastTimestamp = lastRotationUpdateTimestamp else { return }
-
-        let deltaTime = now.timeIntervalSince(lastTimestamp)
-
         handStateLock.lock()
         let handStates = cachedHandStates
         handStateLock.unlock()
@@ -385,10 +381,6 @@ class VisionSceneRenderer {
                 interactionState.singleHandOffset = interactionState.translation - pinchPosition
             } else if pinchedHands.count >= 2 {
                 beginTwoHandGesture(with: handStates)
-            } else {
-                let deltaAngle = Constants.rotationPerSecond * deltaTime
-                let deltaQuat = simd_quatf(angle: Float(deltaAngle.radians), axis: Constants.rotationAxis)
-                interactionState.rotation = deltaQuat * interactionState.rotation
             }
         case .singleHandGrab(let chirality):
             let otherPinchedCount = pinchedHands.count


### PR DESCRIPTION
## Summary
- stop applying delta rotation when no hands are pinched in the vision scene renderer
- keep the rotation timestamp updates so future gesture deltas remain stable

## Testing
- swift build *(fails: visionOS dependencies such as Metal/os are unavailable on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68ffba36551c8321825578c8dd57b700