### PR TITLE
Bind spherical harmonics buffer for splat rendering

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -55,6 +55,7 @@ vertex FragmentIn multiStageSplatVertexShader(uint vertexID [[vertex_id]],
                                               uint instanceID [[instance_id]],
                                               ushort amplificationID [[amplification_id]],
                                               constant Splat* splatArray [[ buffer(BufferIndexSplat) ]],
+                                              constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
                                               constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
     Uniforms uniforms = uniformsArray.uniforms[min(int(amplificationID), kMaxViewCount)];
 
@@ -70,16 +71,19 @@ vertex FragmentIn multiStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.normal = half3(0);
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
+        out.splatIndex = 0;
         return out;
     }
 
     Splat splat = splatArray[splatID];
 
-    return splatVertex(splat, uniforms, vertexID % 4);
+    (void)splatSHArray;
+    return splatVertex(splat, uniforms, vertexID % 4, splatID);
 }
 
 fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
-                                                     FragmentValues previousFragmentValues [[imageblock_data]]) {
+                                                     FragmentValues previousFragmentValues [[imageblock_data]],
+                                                     constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]]) {
     FragmentStore out;
 
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a); // restored: use real coverage
@@ -87,6 +91,8 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
         out.values = previousFragmentValues;
         return out;
     }
+
+    (void)splatSHArray;
 
     half oneMinusAlpha = 1 - alpha;
     half ao = computeAmbientOcclusion(in.color.a);
@@ -125,6 +131,7 @@ vertex FragmentIn postprocessVertexShader(uint vertexID [[vertex_id]]) {
     out.normal = half3(0);
     out.worldPosition = float3(0);
     out.viewDirection = float3(0);
+    out.splatIndex = 0;
     return out;
 }
 

--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -11,6 +11,7 @@ enum BufferIndex: int32_t
 {
     BufferIndexUniforms = 0,
     BufferIndexSplat    = 1,
+    BufferIndexSphericalHarmonics = 2,
 };
 
 enum TextureIndex: int32_t
@@ -63,6 +64,28 @@ typedef struct
 
 typedef struct
 {
+    ushort count;
+    ushort padding;
+    packed_half3 coefficient0;
+    packed_half3 coefficient1;
+    packed_half3 coefficient2;
+    packed_half3 coefficient3;
+    packed_half3 coefficient4;
+    packed_half3 coefficient5;
+    packed_half3 coefficient6;
+    packed_half3 coefficient7;
+    packed_half3 coefficient8;
+    packed_half3 coefficient9;
+    packed_half3 coefficient10;
+    packed_half3 coefficient11;
+    packed_half3 coefficient12;
+    packed_half3 coefficient13;
+    packed_half3 coefficient14;
+    packed_half3 coefficient15;
+} SplatSHCoefficients;
+
+typedef struct
+{
     float4 position [[position]];
     half2 relativePosition; // Ranges from -kBoundsRadius to +kBoundsRadius
     half4 color;
@@ -72,4 +95,5 @@ typedef struct
     half3 normal;
     float3 worldPosition;
     float3 viewDirection;
+    uint  splatIndex;
 } FragmentIn;

--- a/MetalSplatter/Resources/SingleStageRenderPath.metal
+++ b/MetalSplatter/Resources/SingleStageRenderPath.metal
@@ -4,6 +4,7 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
                                                uint instanceID [[instance_id]],
                                                ushort amplificationID [[amplification_id]],
                                                constant Splat* splatArray [[ buffer(BufferIndexSplat) ]],
+                                               constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
                                                constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
     Uniforms uniforms = uniformsArray.uniforms[min(int(amplificationID), kMaxViewCount)];
 
@@ -19,23 +20,28 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.normal = half3(0);
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
+        out.splatIndex = 0;
         return out;
     }
 
     Splat splat = splatArray[splatID];
 
-    return splatVertex(splat, uniforms, vertexID % 4);
+    (void)splatSHArray;
+    return splatVertex(splat, uniforms, vertexID % 4, splatID);
 }
 
 fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]],
                                              texturecube<half> environmentMap [[texture(TextureIndexEnvironment)]],
                                              texture2d<half> brdfLUT [[texture(TextureIndexBRDF)]],
                                              sampler environmentSampler [[sampler(SamplerIndexEnvironment)]],
-                                             sampler brdfSampler [[sampler(SamplerIndexBRDF)]]) {
+                                             sampler brdfSampler [[sampler(SamplerIndexBRDF)]],
+                                             constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]]) {
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a);
     if (alpha <= 0) {
         return half4(0);
     }
+
+    (void)splatSHArray;
 
     half ao = computeAmbientOcclusion(in.color.a);
     half3 shaded = shadeGaussian(in.albedo,

--- a/MetalSplatter/Resources/SplatProcessing.h
+++ b/MetalSplatter/Resources/SplatProcessing.h
@@ -11,7 +11,8 @@ void decomposeCovariance(float3 cov2D, thread float2 &v1, thread float2 &v2);
 
 FragmentIn splatVertex(Splat splat,
                        Uniforms uniforms,
-                       uint relativeVertexIndex);
+                       uint relativeVertexIndex,
+                       uint splatIndex);
 
 half splatFragmentAlpha(half2 relativePosition, half splatAlpha);
 

--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -154,7 +154,8 @@ void decomposeCovariance(float3 cov2D, thread float2 &v1, thread float2 &v2) {
 
 FragmentIn splatVertex(Splat splat,
                        Uniforms uniforms,
-                       uint relativeVertexIndex) {
+                       uint relativeVertexIndex,
+                       uint splatIndex) {
     FragmentIn out;
 
     float4 viewPosition4 = uniforms.viewMatrix * float4(splat.position, 1);
@@ -185,6 +186,7 @@ FragmentIn splatVertex(Splat splat,
         out.normal = half3(0);
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
+        out.splatIndex = splatIndex;
         return out;
     }
 
@@ -227,6 +229,7 @@ FragmentIn splatVertex(Splat splat,
     float3 cameraPosition = uniforms.cameraPosition.xyz;
     float3 viewDirection = safeNormalize(cameraPosition - worldPosition, float3(0, 0, 1));
     out.viewDirection = viewDirection;
+    out.splatIndex = splatIndex;
     return out;
 }
 

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -246,6 +246,7 @@ public class SplatRenderer {
     enum BufferIndex: NSInteger {
         case uniforms = 0
         case splat    = 1
+        case sphericalHarmonics = 2
     }
 
     // Keep in sync with Shaders.metal : TextureIndex
@@ -1066,6 +1067,8 @@ public class SplatRenderer {
 
         renderEncoder.setVertexBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
         renderEncoder.setVertexBuffer(splatBuffer.buffer, offset: 0, index: BufferIndex.splat.rawValue)
+        renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+        renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
 
         renderEncoder.drawIndexedPrimitives(type: .triangle,
                                             indexCount: indexCount,
@@ -1086,6 +1089,8 @@ public class SplatRenderer {
             renderEncoder.setCullMode(.none)
             Self.log.debug("Postprocess: binding material resources before draw")
             bindMaterialResources(to: renderEncoder)
+            renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+            renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
             renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
             renderEncoder.popDebugGroup()
         } else {


### PR DESCRIPTION
## Summary
- add spherical harmonics buffer slot and splat index plumbing to the shared shader structures
- forward splat identifiers through the vertex stage and expose spherical harmonics buffers to fragment shaders
- bind the spherical harmonics buffer for single-stage, multi-stage, and post-process draws in the renderer

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffcc00c33c8321bc177aa718c77c79