### PR TITLE
Add bundled Gaussian splat picker to sample app

### DIFF
--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -26,9 +26,11 @@
 		61791E022B415D3F00302B57 /* SampleBoxRenderer in Frameworks */ = {isa = PBXBuildFile; productRef = 61791E012B415D3F00302B57 /* SampleBoxRenderer */; };
 		61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E0E2B41685800302B57 /* MetalKitSceneRenderer.swift */; };
 		61791E132B416DD700302B57 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E112B416DCF00302B57 /* Constants.swift */; };
-		61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
-		617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
-		617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
+                61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61791E142B42294700302B57 /* MetalKitSceneView.swift */; };
+                617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
+                617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
+                61B9F0A12BC4D50000AA0001 /* PreloadedGaussianModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9F0A02BC4D50000AA0001 /* PreloadedGaussianModel.swift */; };
+                61B9F0A32BC4D50000AA0001 /* GaussianSplats in Resources */ = {isa = PBXBuildFile; fileRef = 61B9F0A22BC4D50000AA0001 /* GaussianSplats */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,7 +53,9 @@
                 61A1AA002B7C000100A1AA00 /* EnvironmentProbeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProbeManager.swift; sourceTree = "<group>"; };
                 61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentPrefilter.swift; sourceTree = "<group>"; };
                 61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = EnvironmentPrefilter.metal; sourceTree = "<group>"; };
-		617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+                617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+                61B9F0A02BC4D50000AA0001 /* PreloadedGaussianModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadedGaussianModel.swift; sourceTree = "<group>"; };
+                61B9F0A22BC4D50000AA0001 /* GaussianSplats */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GaussianSplats; path = GaussianSplats; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,17 +73,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		610347DF2B4689DB00693CE3 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				61791DDB2B4154FB00302B57 /* ModelIdentifier.swift */,
-				61791DDE2B4154FB00302B57 /* ModelRenderer.swift */,
-				61791DDC2B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift */,
-				61791DDA2B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
+                610347DF2B4689DB00693CE3 /* Model */ = {
+                        isa = PBXGroup;
+                        children = (
+                                61791DDB2B4154FB00302B57 /* ModelIdentifier.swift */,
+                                61791DDE2B4154FB00302B57 /* ModelRenderer.swift */,
+                                61791DDC2B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift */,
+                                61791DDA2B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift */,
+                                61B9F0A02BC4D50000AA0001 /* PreloadedGaussianModel.swift */,
+                        );
+                        path = Model;
+                        sourceTree = "<group>";
+                };
+                61B9F0A42BC4D50000AA0001 /* Resources */ = {
+                        isa = PBXGroup;
+                        children = (
+                                61B9F0A22BC4D50000AA0001 /* GaussianSplats */,
+                        );
+                        path = Resources;
+                        sourceTree = "<group>";
+                };
                 610347E02B468A0000693CE3 /* Scene */ = {
                         isa = PBXGroup;
                         children = (
@@ -129,20 +142,21 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		61E3FD792AE5CB0200032652 = {
-			isa = PBXGroup;
-			children = (
-				610347E22B468A1100693CE3 /* App */,
-				610347E12B468A0B00693CE3 /* Util */,
-				610347E02B468A0000693CE3 /* Scene */,
-				610347DF2B4689DB00693CE3 /* Model */,
-				61791DF82B41551F00302B57 /* Info.plist */,
-				61791DC32B41514300302B57 /* Assets.xcassets */,
-				61E3FD832AE5CB0200032652 /* Products */,
-				619832682AF0BC390022500D /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
+                61E3FD792AE5CB0200032652 = {
+                        isa = PBXGroup;
+                        children = (
+                                610347E22B468A1100693CE3 /* App */,
+                                610347E12B468A0B00693CE3 /* Util */,
+                                610347E02B468A0000693CE3 /* Scene */,
+                                610347DF2B4689DB00693CE3 /* Model */,
+                                61B9F0A42BC4D50000AA0001 /* Resources */,
+                                61791DF82B41551F00302B57 /* Info.plist */,
+                                61791DC32B41514300302B57 /* Assets.xcassets */,
+                                61E3FD832AE5CB0200032652 /* Products */,
+                                619832682AF0BC390022500D /* Frameworks */,
+                        );
+                        sourceTree = "<group>";
+                };
 		61E3FD832AE5CB0200032652 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -214,13 +228,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		617E50AE2B314BE200F99766 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                617E50AE2B314BE200F99766 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                61B9F0A32BC4D50000AA0001 /* GaussianSplats in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -235,6 +250,7 @@
                                 61791DE42B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift in Sources */,
                                 61791DEA2B4154FB00302B57 /* MatrixMathUtil.swift in Sources */,
                                 610347DB2B46875700693CE3 /* VisionSceneRenderer.swift in Sources */,
+                                61B9F0A12BC4D50000AA0001 /* PreloadedGaussianModel.swift in Sources */,
                                 610347D92B46864500693CE3 /* SampleApp.swift in Sources */,
                                 61791E102B41688000302B57 /* MetalKitSceneRenderer.swift in Sources */,
                                 61A1AA072B7C000100A1AA00 /* EnvironmentPrefilter.swift in Sources */,

--- a/SampleApp/Model/ModelIdentifier.swift
+++ b/SampleApp/Model/ModelIdentifier.swift
@@ -7,7 +7,8 @@ enum ModelIdentifier: Equatable, Hashable, Codable, CustomStringConvertible {
     var description: String {
         switch self {
         case .gaussianSplat(let url):
-            "Gaussian Splat: \(url.path)"
+            let filename = url.deletingPathExtension().lastPathComponent
+            return "Gaussian Splat: \(filename)"
         case .sampleBox:
             "Sample Box"
         }

--- a/SampleApp/Model/PreloadedGaussianModel.swift
+++ b/SampleApp/Model/PreloadedGaussianModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum PreloadedGaussianModel: String, CaseIterable, Identifiable {
+    case holzablage
+    case klavierbank
+    case glastisch
+    case holztisch
+    case lampe
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .holzablage:
+            return "Holzablage"
+        case .klavierbank:
+            return "Klavierbank"
+        case .glastisch:
+            return "Glastisch"
+        case .holztisch:
+            return "Holztisch"
+        case .lampe:
+            return "Lampe"
+        }
+    }
+
+    var resourceFileName: String {
+        "GIR_\(rawValue)_30000"
+    }
+
+    var bundleURL: URL? {
+        Bundle.main.url(forResource: resourceFileName, withExtension: "ply")
+    }
+
+    var resourceMissingMessage: String {
+        "Could not find \(resourceFileName).ply in the bundled Gaussian Splats resources. Add the file to SampleApp/Resources/GaussianSplats before building."
+    }
+}

--- a/SampleApp/Resources/GaussianSplats/README.md
+++ b/SampleApp/Resources/GaussianSplats/README.md
@@ -1,0 +1,12 @@
+# Gaussian Splat Resources
+
+Place the evaluation PLY assets in this directory before building the app.
+
+Expected filenames:
+- `GIR_holzablage_30000.ply`
+- `GIR_klavierbank_30000.ply`
+- `GIR_glastisch_30000.ply`
+- `GIR_holztisch_30000.ply`
+- `GIR_lampe_30000.ply`
+
+The files will be bundled with the application automatically when added here.

--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 import RealityKit
-import UniformTypeIdentifiers
 
 struct ContentView: View {
-    @State private var isPickingFile = false
+    @State private var missingModelAlert: PreloadedGaussianModel?
 
 #if os(macOS)
     @Environment(\.openWindow) private var openWindow
@@ -56,36 +55,26 @@ struct ContentView: View {
 
             Spacer()
 
-            Button("Read Scene File") {
-                isPickingFile = true
-            }
-            .padding()
-            .buttonStyle(.borderedProminent)
-            .disabled(isPickingFile)
-#if os(visionOS)
-            .disabled(immersiveSpaceIsShown)
-#endif
-            .fileImporter(isPresented: $isPickingFile,
-                          allowedContentTypes: [
-                            UTType(filenameExtension: "ply")!,
-                            UTType(filenameExtension: "splat")!,
-                          ]) {
-                isPickingFile = false
-                switch $0 {
-                case .success(let url):
-                    _ = url.startAccessingSecurityScopedResource()
-                    Task {
-                        // This is a sample app. In a real app, this should be more tightly scoped, not using a silly timer.
-                        try await Task.sleep(for: .seconds(10))
-                        url.stopAccessingSecurityScopedResource()
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(PreloadedGaussianModel.allCases) { model in
+                    Button(model.displayName) {
+                        guard let url = model.bundleURL else {
+                            missingModelAlert = model
+                            return
+                        }
+                        openWindow(value: ModelIdentifier.gaussianSplat(url))
                     }
-                    openWindow(value: ModelIdentifier.gaussianSplat(url))
-                case .failure:
-                    break
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal)
+                    .buttonStyle(.borderedProminent)
+#if os(visionOS)
+                    .disabled(immersiveSpaceIsShown)
+#endif
                 }
             }
+            .padding(.horizontal)
 
-            Spacer()
+            Spacer(minLength: 24)
 
             Button("Show Sample Box") {
                 openWindow(value: ModelIdentifier.sampleBox)
@@ -109,6 +98,13 @@ struct ContentView: View {
 
             Spacer()
 #endif // os(visionOS)
+        }
+        .alert(item: $missingModelAlert) { model in
+            Alert(
+                title: Text("Model Not Found"),
+                message: Text(model.resourceMissingMessage),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a catalog of preloaded Gaussian splat entries and surface them as buttons in the main UI
- bundle a GaussianSplats resource folder so the five evaluation PLY files ship with the app
- polish Gaussian splat model descriptions to show friendly filenames

## Testing
- `swift build` *(fails on Linux due to missing Apple frameworks such as Metal and os)*

------
https://chatgpt.com/codex/tasks/task_e_68ffd18db3888321874661363ec9fbc7