### PR TITLE
Add SH metadata configuration and debug views

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -3,6 +3,7 @@
 
 // Debug visualization selector:
 // 0: coverage (alpha), 1: albedo, 2: normal, 3: roughness, 4: metallic, 5: AO, 6: depth, 7: shaded (default)
+// 28: diffuse SH only, 29: specular SH only
 #ifndef DEBUG_VIEW
 #define DEBUG_VIEW 1
 #endif
@@ -86,8 +87,10 @@ vertex FragmentIn multiStageSplatVertexShader(uint vertexID [[vertex_id]],
 }
 
 fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
+                                                     ushort viewIndex [[render_target_array_index]],
                                                      FragmentValues previousFragmentValues [[imageblock_data]],
-                                                     constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]]) {
+                                                     constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
+                                                     constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
     FragmentStore out;
 
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a); // restored: use real coverage
@@ -99,13 +102,23 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
     half oneMinusAlpha = 1 - alpha;
     half ao = computeAmbientOcclusion(in.color.a);
 
+    Uniforms uniforms = uniformsArray.uniforms[min(int(viewIndex), kMaxViewCount)];
+    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
     SplatSHCoefficients shCoefficients = splatSHArray[in.splatIndex];
     float3 normal = safeNormalize(float3(in.normal), float3(0, 0, 1));
     float3 viewDirection = safeNormalize(float3(in.viewDirection), float3(0, 0, 1));
     float3 reflectionDirection = reflect(-viewDirection, normal);
 
-    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, normal);
-    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, reflectionDirection);
+    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
+    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+
+    uint shMask = uniforms.useSHMask;
+    if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {
+        diffuseSH = float3(0);
+    }
+    if ((shMask & SphericalHarmonicsUsageSpecular) == 0) {
+        specularSH = float3(0);
+    }
 
     half4 albedoMetallic = half4(in.albedo * alpha, in.metallic * alpha);
     half4 normalRoughness = half4(half3(normal) * alpha, in.roughness * alpha);
@@ -308,6 +321,18 @@ inline half4 resolveFragmentValues(FragmentValues fragmentValues,
     {
         half2 l = brdfLUT.sample(brdfSampler, float2(0.5, 0.5)).rg;
         return half4(l.x, l.y, 0, 1);
+    }
+#elif DEBUG_VIEW == 28
+    // Diffuse spherical harmonics contribution only (accumulated)
+    {
+        half3 sh = half3(diffuseSH) * accumulatedAlpha;
+        return half4(sh, accumulatedAlpha);
+    }
+#elif DEBUG_VIEW == 29
+    // Specular spherical harmonics contribution only (accumulated)
+    {
+        half3 sh = half3(specularSH) * accumulatedAlpha;
+        return half4(sh, accumulatedAlpha);
     }
 #elif DEBUG_VIEW == 7
     // Shaded result (uses environment)

--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -26,6 +26,12 @@ enum SamplerIndex: int32_t
     SamplerIndexBRDF        = 1,
 };
 
+enum SphericalHarmonicsUsageMask : uint
+{
+    SphericalHarmonicsUsageDiffuse  = 1u << 0,
+    SphericalHarmonicsUsageSpecular = 1u << 1,
+};
+
 typedef struct
 {
     matrix_float4x4 projectionMatrix;
@@ -41,7 +47,8 @@ typedef struct
      */
     uint splatCount;
     uint indexedSplatCount;
-    uint2 _paddingCounts;
+    uint shCoefficientCount;
+    uint useSHMask;
 } Uniforms;
 
 typedef struct

--- a/MetalSplatter/Resources/SingleStageRenderPath.metal
+++ b/MetalSplatter/Resources/SingleStageRenderPath.metal
@@ -31,23 +31,35 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
 }
 
 fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]],
+                                             ushort viewIndex [[render_target_array_index]],
                                              texturecube<half> environmentMap [[texture(TextureIndexEnvironment)]],
                                              texture2d<half> brdfLUT [[texture(TextureIndexBRDF)]],
                                              sampler environmentSampler [[sampler(SamplerIndexEnvironment)]],
                                              sampler brdfSampler [[sampler(SamplerIndexBRDF)]],
-                                             constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]]) {
+                                             constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
+                                             constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a);
     if (alpha <= 0) {
         return half4(0);
     }
 
+    Uniforms uniforms = uniformsArray.uniforms[min(int(viewIndex), kMaxViewCount)];
+    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
     SplatSHCoefficients shCoefficients = splatSHArray[in.splatIndex];
     float3 normal = safeNormalize(float3(in.normal), float3(0, 0, 1));
     float3 viewDirection = safeNormalize(float3(in.viewDirection), float3(0, 0, 1));
     float3 reflectionDirection = reflect(-viewDirection, normal);
 
-    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, normal);
-    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, reflectionDirection);
+    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
+    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+
+    uint shMask = uniforms.useSHMask;
+    if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {
+        diffuseSH = float3(0);
+    }
+    if ((shMask & SphericalHarmonicsUsageSpecular) == 0) {
+        specularSH = float3(0);
+    }
 
     half ao = computeAmbientOcclusion(in.color.a);
     half3 shaded = shadeGaussian(in.albedo,

--- a/MetalSplatter/Resources/SplatProcessing.h
+++ b/MetalSplatter/Resources/SplatProcessing.h
@@ -18,6 +18,13 @@ half splatFragmentAlpha(half2 relativePosition, half splatAlpha);
 
 half computeAmbientOcclusion(half opacity);
 
+float3 evaluateSplatSHForDiffuse(SplatSHCoefficients coefficients,
+                                 ushort coefficientCount,
+                                 float3 normal);
+float3 evaluateSplatSHForSpecular(SplatSHCoefficients coefficients,
+                                  ushort coefficientCount,
+                                  float3 reflectionDirection);
+
 half3 shadeGaussian(half3 albedo,
                     half metallic,
                     half roughness,

--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -42,8 +42,10 @@ float3 sampleDiffuseIrradiance(texturecube<half> environmentMap,
     return float3(environmentMap.sample(environmentSampler, normal, level(float(diffuseMip))).rgb);
 }
 
-float3 evaluateSplatSHCoefficients(SplatSHCoefficients coefficients, float3 direction) {
-    ushort count = coefficients.count;
+float3 evaluateSplatSHCoefficients(SplatSHCoefficients coefficients,
+                                   ushort coefficientCount,
+                                   float3 direction) {
+    ushort count = min(coefficients.count, coefficientCount);
     if (count == 0) {
         return float3(0);
     }
@@ -148,12 +150,20 @@ float3 evaluateSplatSHCoefficients(SplatSHCoefficients coefficients, float3 dire
     return result;
 }
 
-float3 evaluateSplatSHForDiffuse(SplatSHCoefficients coefficients, float3 normal) {
-    return (coefficients.count == 0) ? float3(0) : evaluateSplatSHCoefficients(coefficients, normal);
+float3 evaluateSplatSHForDiffuse(SplatSHCoefficients coefficients,
+                                 ushort coefficientCount,
+                                 float3 normal) {
+    return (coefficients.count == 0 || coefficientCount == 0)
+        ? float3(0)
+        : evaluateSplatSHCoefficients(coefficients, coefficientCount, normal);
 }
 
-float3 evaluateSplatSHForSpecular(SplatSHCoefficients coefficients, float3 reflectionDirection) {
-    return (coefficients.count == 0) ? float3(0) : evaluateSplatSHCoefficients(coefficients, reflectionDirection);
+float3 evaluateSplatSHForSpecular(SplatSHCoefficients coefficients,
+                                  ushort coefficientCount,
+                                  float3 reflectionDirection) {
+    return (coefficients.count == 0 || coefficientCount == 0)
+        ? float3(0)
+        : evaluateSplatSHCoefficients(coefficients, coefficientCount, reflectionDirection);
 }
 
 half3 shadeGaussian(half3 albedo,

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -271,7 +271,8 @@ public class SplatRenderer {
 
         var splatCount: UInt32
         var indexedSplatCount: UInt32
-        var paddingCounts: SIMD2<UInt32> = .zero
+        var shCoefficientCount: UInt32
+        var useSHMask: UInt32
     }
 
     // Keep in sync with Shaders.metal : UniformsArray
@@ -444,6 +445,14 @@ public class SplatRenderer {
     var uniformBufferIndex = 0
     var uniforms: UnsafeMutablePointer<UniformsArray>
 
+    private var configuredSphericalHarmonicsCoefficientCount: UInt32?
+    private var configuredSphericalHarmonicsUsageMask: UInt32?
+    private var derivedSphericalHarmonicsCoefficientCount: UInt32 = 0
+
+    public var gaussianImageRepresentationMetadata: GaussianImageRepresentationMetadata? {
+        didSet { updateGaussianImageRepresentationMetadata() }
+    }
+
     // cameraWorldPosition and Forward vectors are the latest mean camera position across all viewports
     var cameraWorldPosition: SIMD3<Float> = .zero
     var cameraWorldForward: SIMD3<Float> = .init(x: 0, y: 0, z: -1)
@@ -517,6 +526,8 @@ public class SplatRenderer {
         } catch {
             fatalError("Unable to initialize SplatRenderer: \(error)")
         }
+
+        updateGaussianImageRepresentationMetadata()
     }
 
     public func reset() {
@@ -524,6 +535,7 @@ public class SplatRenderer {
         try? splatBuffer.setCapacity(0)
         splatSHBuffer.count = 0
         try? splatSHBuffer.setCapacity(0)
+        derivedSphericalHarmonicsCoefficientCount = 0
     }
 
     public func setEnvironmentMap(_ texture: MTLTexture?) throws {
@@ -750,6 +762,8 @@ public class SplatRenderer {
                     .prefix(SphericalHarmonicConstants.maxCoefficientCount)
             )
             let activatedCoefficients = Self.activateSphericalHarmonics(sanitizedCoefficients)
+            derivedSphericalHarmonicsCoefficientCount = max(derivedSphericalHarmonicsCoefficientCount,
+                                                            UInt32(activatedCoefficients.count))
             splatSHBuffer.append(SplatSHCoefficients(coefficients: activatedCoefficients))
         }
     }
@@ -786,6 +800,27 @@ public class SplatRenderer {
         materialFallbackTelemetry = MaterialFallbackTelemetry()
         didLogEnvironmentFallbackThisFrame = false
         didLogBRDFFallbackThisFrame = false
+    }
+
+    private func updateGaussianImageRepresentationMetadata() {
+        configuredSphericalHarmonicsCoefficientCount = gaussianImageRepresentationMetadata?.sphericalHarmonicsCoefficientCount
+        if let usage = gaussianImageRepresentationMetadata?.sphericalHarmonicsUsage {
+            configuredSphericalHarmonicsUsageMask = usage.rawValue
+        } else {
+            configuredSphericalHarmonicsUsageMask = nil
+        }
+    }
+
+    private func effectiveSphericalHarmonicsCoefficientCount() -> UInt32 {
+        configuredSphericalHarmonicsCoefficientCount ?? derivedSphericalHarmonicsCoefficientCount
+    }
+
+    private func effectiveSphericalHarmonicsUsageMask() -> UInt32 {
+        if let configuredMask = configuredSphericalHarmonicsUsageMask {
+            return configuredMask
+        }
+        let coefficientCount = effectiveSphericalHarmonicsCoefficientCount()
+        return coefficientCount == 0 ? 0 : GaussianImageRepresentationSphericalHarmonicsUsage.all.rawValue
     }
 
     private func switchToNextDynamicBuffer() {
@@ -911,6 +946,8 @@ public class SplatRenderer {
     private func updateUniforms(forViewports viewports: [ViewportDescriptor],
                                 splatCount: UInt32,
                                 indexedSplatCount: UInt32) {
+        let shCoefficientCount = effectiveSphericalHarmonicsCoefficientCount()
+        let shMask = effectiveSphericalHarmonicsUsageMask()
         for (i, viewport) in viewports.enumerated() where i <= maxViewCount {
             let cameraPosition = Self.cameraWorldPosition(forViewMatrix: viewport.viewMatrix)
             let uniforms = Uniforms(projectionMatrix: viewport.projectionMatrix,
@@ -918,7 +955,9 @@ public class SplatRenderer {
                                     screenSize: SIMD2(x: UInt32(viewport.screenSize.x), y: UInt32(viewport.screenSize.y)),
                                     cameraPosition: SIMD4<Float>(cameraPosition, 1),
                                     splatCount: splatCount,
-                                    indexedSplatCount: indexedSplatCount)
+                                    indexedSplatCount: indexedSplatCount,
+                                    shCoefficientCount: shCoefficientCount,
+                                    useSHMask: shMask)
             self.uniforms.pointee.setUniforms(index: i, uniforms)
         }
 
@@ -1068,6 +1107,7 @@ public class SplatRenderer {
         renderEncoder.setVertexBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
         renderEncoder.setVertexBuffer(splatBuffer.buffer, offset: 0, index: BufferIndex.splat.rawValue)
         renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+        renderEncoder.setFragmentBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
         renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
 
         renderEncoder.drawIndexedPrimitives(type: .triangle,
@@ -1089,6 +1129,7 @@ public class SplatRenderer {
             renderEncoder.setCullMode(.none)
             Self.log.debug("Postprocess: binding material resources before draw")
             bindMaterialResources(to: renderEncoder)
+            renderEncoder.setFragmentBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
             renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
             renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
             renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)

--- a/SplatIO/Sources/GaussianImageRepresentationMetadata.swift
+++ b/SplatIO/Sources/GaussianImageRepresentationMetadata.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct GaussianImageRepresentationSphericalHarmonicsUsage: OptionSet, Sendable {
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static let diffuse = GaussianImageRepresentationSphericalHarmonicsUsage(rawValue: 1 << 0)
+    public static let specular = GaussianImageRepresentationSphericalHarmonicsUsage(rawValue: 1 << 1)
+    public static let all: GaussianImageRepresentationSphericalHarmonicsUsage = [.diffuse, .specular]
+}
+
+public struct GaussianImageRepresentationMetadata: Sendable {
+    public var sphericalHarmonicsCoefficientCount: UInt32?
+    public var sphericalHarmonicsUsage: GaussianImageRepresentationSphericalHarmonicsUsage?
+
+    public init(sphericalHarmonicsCoefficientCount: UInt32? = nil,
+                sphericalHarmonicsUsage: GaussianImageRepresentationSphericalHarmonicsUsage? = nil) {
+        self.sphericalHarmonicsCoefficientCount = sphericalHarmonicsCoefficientCount
+        self.sphericalHarmonicsUsage = sphericalHarmonicsUsage
+    }
+}


### PR DESCRIPTION
## Summary
- add GaussianImageRepresentationMetadata for configuring SH coefficient count and usage
- propagate SH count and usage mask through renderer uniforms to Metal shaders
- add diffuse-only and specular-only SH debug views for validation

## Testing
- swift test *(fails: requires Apple Metal/os frameworks in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffd26a997883219f52ff25bfb188cc