### PR TITLE
Precompute SH lighting in splat vertex stage

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -77,13 +77,24 @@ vertex FragmentIn multiStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
         out.splatIndex = 0;
+        out.diffuseSH = float3(0);
+        out.specularSH = float3(0);
         return out;
     }
 
     Splat splat = splatArray[splatID];
 
-    (void)splatSHArray;
-    return splatVertex(splat, uniforms, vertexID % 4, splatID);
+    FragmentIn out = splatVertex(splat, uniforms, vertexID % 4, splatID);
+
+    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
+    SplatSHCoefficients shCoefficients = splatSHArray[splatID];
+    float3 normal = safeNormalize(float3(out.normal), float3(0, 0, 1));
+    float3 viewDirection = safeNormalize(float3(out.viewDirection), float3(0, 0, 1));
+    float3 reflectionDirection = reflect(-viewDirection, normal);
+    out.diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
+    out.specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+
+    return out;
 }
 
 fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
@@ -92,6 +103,8 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
                                                      constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
                                                      constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
     FragmentStore out;
+
+    (void)splatSHArray;
 
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a); // restored: use real coverage
     if (alpha <= 0) {
@@ -103,14 +116,12 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
     half ao = computeAmbientOcclusion(in.color.a);
 
     Uniforms uniforms = uniformsArray.uniforms[min(int(viewIndex), kMaxViewCount)];
-    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
-    SplatSHCoefficients shCoefficients = splatSHArray[in.splatIndex];
     float3 normal = safeNormalize(float3(in.normal), float3(0, 0, 1));
     float3 viewDirection = safeNormalize(float3(in.viewDirection), float3(0, 0, 1));
     float3 reflectionDirection = reflect(-viewDirection, normal);
 
-    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
-    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+    float3 diffuseSH = in.diffuseSH;
+    float3 specularSH = in.specularSH;
 
     uint shMask = uniforms.useSHMask;
     if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {
@@ -159,6 +170,8 @@ vertex FragmentIn postprocessVertexShader(uint vertexID [[vertex_id]]) {
     out.worldPosition = float3(0);
     out.viewDirection = float3(0);
     out.splatIndex = 0;
+    out.diffuseSH = float3(0);
+    out.specularSH = float3(0);
     return out;
 }
 

--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -103,4 +103,6 @@ typedef struct
     float3 worldPosition;
     float3 viewDirection;
     uint  splatIndex;
+    float3 diffuseSH [[flat]];
+    float3 specularSH [[flat]];
 } FragmentIn;

--- a/MetalSplatter/Resources/SingleStageRenderPath.metal
+++ b/MetalSplatter/Resources/SingleStageRenderPath.metal
@@ -21,13 +21,24 @@ vertex FragmentIn singleStageSplatVertexShader(uint vertexID [[vertex_id]],
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
         out.splatIndex = 0;
+        out.diffuseSH = float3(0);
+        out.specularSH = float3(0);
         return out;
     }
 
     Splat splat = splatArray[splatID];
 
-    (void)splatSHArray;
-    return splatVertex(splat, uniforms, vertexID % 4, splatID);
+    FragmentIn out = splatVertex(splat, uniforms, vertexID % 4, splatID);
+
+    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
+    SplatSHCoefficients shCoefficients = splatSHArray[splatID];
+    float3 normal = safeNormalize(float3(out.normal), float3(0, 0, 1));
+    float3 viewDirection = safeNormalize(float3(out.viewDirection), float3(0, 0, 1));
+    float3 reflectionDirection = reflect(-viewDirection, normal);
+    out.diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
+    out.specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+
+    return out;
 }
 
 fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]],
@@ -38,20 +49,19 @@ fragment half4 singleStageSplatFragmentShader(FragmentIn in [[stage_in]],
                                              sampler brdfSampler [[sampler(SamplerIndexBRDF)]],
                                              constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
                                              constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
+    (void)splatSHArray;
     half alpha = splatFragmentAlpha(in.relativePosition, in.color.a);
     if (alpha <= 0) {
         return half4(0);
     }
 
     Uniforms uniforms = uniformsArray.uniforms[min(int(viewIndex), kMaxViewCount)];
-    ushort configuredCoefficientCount = ushort(min(uniforms.shCoefficientCount, 16u));
-    SplatSHCoefficients shCoefficients = splatSHArray[in.splatIndex];
     float3 normal = safeNormalize(float3(in.normal), float3(0, 0, 1));
     float3 viewDirection = safeNormalize(float3(in.viewDirection), float3(0, 0, 1));
     float3 reflectionDirection = reflect(-viewDirection, normal);
 
-    float3 diffuseSH = evaluateSplatSHForDiffuse(shCoefficients, configuredCoefficientCount, normal);
-    float3 specularSH = evaluateSplatSHForSpecular(shCoefficients, configuredCoefficientCount, reflectionDirection);
+    float3 diffuseSH = in.diffuseSH;
+    float3 specularSH = in.specularSH;
 
     uint shMask = uniforms.useSHMask;
     if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {

--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -317,6 +317,8 @@ FragmentIn splatVertex(Splat splat,
         out.worldPosition = float3(0);
         out.viewDirection = float3(0);
         out.splatIndex = splatIndex;
+        out.diffuseSH = float3(0);
+        out.specularSH = float3(0);
         return out;
     }
 
@@ -360,6 +362,8 @@ FragmentIn splatVertex(Splat splat,
     float3 viewDirection = safeNormalize(cameraPosition - worldPosition, float3(0, 0, 1));
     out.viewDirection = viewDirection;
     out.splatIndex = splatIndex;
+    out.diffuseSH = float3(0);
+    out.specularSH = float3(0);
     return out;
 }
 


### PR DESCRIPTION
## Summary
- extend FragmentIn to carry flat-interpolated diffuse and specular SH contributions
- precompute splat SH lighting in the single-stage and multi-stage vertex shaders
- reuse the precomputed SH values during fragment shading and initialize defaults for all paths

## Testing
- not run (Metal shader changes)


------
https://chatgpt.com/codex/tasks/task_e_68ffe836cf88832188d6c49b82122491