### PR TITLE
Add spherical harmonics debug view modes

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -62,6 +62,8 @@ public class SplatRenderer {
         case normalRaw = 25
         case normalDifference = 26
         case normalDotComparison = 27
+        case sphericalHarmonicsDiffuse = 28
+        case sphericalHarmonicsSpecular = 29
     }
 
     public enum Error: Swift.Error, LocalizedError {

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -64,6 +64,10 @@ extension SplatRenderer.DebugViewMode {
             return "Normal Δ"
         case .normalDotComparison:
             return "N·V Compare"
+        case .sphericalHarmonicsDiffuse:
+            return "SH Diffuse"
+        case .sphericalHarmonicsSpecular:
+            return "SH Specular"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add spherical harmonics diffuse and specular debug view modes aligned with shader constants
- expose readable labels for the new debug view modes in the renderer settings UI

## Testing
- `swift build` *(fails: missing platform-specific modules such as os and Metal in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fffb7d85748321b046c8e47ec7224e