### PR TITLE
Fix MultiStage debug handling for spherical harmonics modes

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -286,81 +286,17 @@ if (DEBUG_VIEW_VALUE == 1) {
 } else if (DEBUG_VIEW_VALUE == 25) {
     // Raw (pre-decode) normal visualization
     return half4(normal_raw * 0.5h + 0.5h, 1);
-}
-
-// NOTE: case 26 (“difference heatmap”) was omitted here because its body
-// wasn't present in your snippet. Add it later if needed.
-
-// If we get here, proceed with your regular PBR/SH shading…
-        half3 diff = abs(normal_dec - normal_raw);
-        return half4(diff, 1);
-    } else if (DEBUG_VIEW_VALUE == 27) {
-        // N·V comparison: R=using decoded normal, G=using raw normal
-        half3 V = normalize(viewDir);
-        half ndv_dec = saturate(dot(normal_dec, V));
-        half ndv_raw = saturate(dot(normal_raw, V));
-        return half4(ndv_dec, ndv_raw, 0.0h, 1);
-    } else if (DEBUG_VIEW_VALUE == 8) {
-        // Shaded result with AO forced to 1 (tests if AO is zeroing energy)
-        half3 shaded = shadeGaussian(albedo,
-                                     metallic,
-                                     roughness,
-                                     shadingNormal,
-                                     shadingView,
-                                     shadingReflection,
-                                     half(1.0),   // force AO = 1
-                                     diffuseSH,
-                                     specularSH,
-                                     environmentMap,
-                                     brdfLUT,
-                                     environmentSampler,
-                                     brdfSampler);
-        return half4(shaded * accumulatedAlpha, accumulatedAlpha);
-    } else if (DEBUG_VIEW_VALUE == 9) {
-        // Direct environment reflection sample (tests env binding/indices)
-        half3 N = normalize(normal);
-        half3 V = normalize(viewDir);
-        half3 R = reflect(-V, N);
-        half3 env = environmentMap.sample(environmentSampler, float3(R)).rgb;
-        return half4(env, 1);
-    } else if (DEBUG_VIEW_VALUE == 10) {
-        // N·V visualization (tests geometry/normal-view relationship)
-        half3 N = normalize(normal);
-        half3 V = normalize(viewDir);
-        half ndv = saturate(dot(N, V));
-        return half4(ndv, ndv, ndv, 1);
-    } else if (DEBUG_VIEW_VALUE == 12) {
-        // Simple Lambert with a fixed key light (no env/BRDF) to prove shading path works
-        half3 N = normalize(normal);
-        half3 L = normalize(half3(0.4h, 0.8h, 0.4h));
-        half ndl = saturate(dot(N, L));
-        half3 lit = albedo * ndl;
-        return half4(lit * accumulatedAlpha, accumulatedAlpha);
-    } else if (DEBUG_VIEW_VALUE == 13) {
-        // BRDF LUT debug: show LUT sample at center to validate BRDF binding
-        half2 l = brdfLUT.sample(brdfSampler, float2(0.5, 0.5)).rg;
-        return half4(l.x, l.y, 0, 1);
-    } else if (DEBUG_VIEW_VALUE == 7) {
-        // Shaded result (uses environment)
-        half3 shaded = shadeGaussian(albedo,
-                                     metallic,
-                                     roughness,
-                                     normal_dec,
-                                     viewDir,
-                                     ao,
-                                     environmentMap,
-                                     brdfLUT,
-                                     environmentSampler,
-                                     brdfSampler);
-        return half4(shaded * accumulatedAlpha, accumulatedAlpha);
-    } else {
-        // Coverage and depth handled in postprocess
-        return half4(0);
-    }
-// UI-driven debug modes (function constant)
-// 28: diffuse SH only, 29: specular SH only, 7: full shaded, else: coverage/depth handled in post
-
-if (DEBUG_VIEW_VALUE == 28) {
+} else if (DEBUG_VIEW_VALUE == 26) {
+    // Difference heatmap between decoded and raw normals
+    half3 diff = abs(normal_dec - normal_raw);
+    return half4(diff, 1);
+} else if (DEBUG_VIEW_VALUE == 27) {
+    // N·V comparison: R=using decoded normal, G=using raw normal
+    half3 V = normalize(viewDir);
+    half ndv_dec = saturate(dot(normal_dec, V));
+    half ndv_raw = saturate(dot(normal_raw, V));
+    return half4(ndv_dec, ndv_raw, 0.0h, 1);
+} else if (DEBUG_VIEW_VALUE == 28) {
     // Diffuse spherical harmonics contribution only (accumulated)
     half3 sh = half3(diffuseSH) * accumulatedAlpha;
     return half4(sh, accumulatedAlpha);
@@ -368,23 +304,61 @@ if (DEBUG_VIEW_VALUE == 28) {
     // Specular spherical harmonics contribution only (accumulated)
     half3 sh = half3(specularSH) * accumulatedAlpha;
     return half4(sh, accumulatedAlpha);
+} else if (DEBUG_VIEW_VALUE == 8) {
+    // Shaded result with AO forced to 1 (tests if AO is zeroing energy)
+    half3 shaded = shadeGaussian(albedo,
+                                 metallic,
+                                 roughness,
+                                 shadingNormal,
+                                 shadingView,
+                                 shadingReflection,
+                                 half(1.0),   // force AO = 1
+                                 diffuseSH,
+                                 specularSH,
+                                 environmentMap,
+                                 brdfLUT,
+                                 environmentSampler,
+                                 brdfSampler);
+    return half4(shaded * accumulatedAlpha, accumulatedAlpha);
+} else if (DEBUG_VIEW_VALUE == 9) {
+    // Direct environment reflection sample (tests env binding/indices)
+    half3 N = normalize(normal);
+    half3 V = normalize(viewDir);
+    half3 R = reflect(-V, N);
+    half3 env = environmentMap.sample(environmentSampler, float3(R)).rgb;
+    return half4(env, 1);
+} else if (DEBUG_VIEW_VALUE == 10) {
+    // N·V visualization (tests geometry/normal-view relationship)
+    half3 N = normalize(normal);
+    half3 V = normalize(viewDir);
+    half ndv = saturate(dot(N, V));
+    return half4(ndv, ndv, ndv, 1);
+} else if (DEBUG_VIEW_VALUE == 12) {
+    // Simple Lambert with a fixed key light (no env/BRDF) to prove shading path works
+    half3 N = normalize(normal);
+    half3 L = normalize(half3(0.4h, 0.8h, 0.4h));
+    half ndl = saturate(dot(N, L));
+    half3 lit = albedo * ndl;
+    return half4(lit * accumulatedAlpha, accumulatedAlpha);
+} else if (DEBUG_VIEW_VALUE == 13) {
+    // BRDF LUT debug: show LUT sample at center to validate BRDF binding
+    half2 l = brdfLUT.sample(brdfSampler, float2(0.5, 0.5)).rg;
+    return half4(l.x, l.y, 0, 1);
 } else if (DEBUG_VIEW_VALUE == 7) {
     // Shaded result (uses environment)
-    half3 shaded = shadeGaussian(
-        albedo,
-        metallic,
-        roughness,
-        shadingNormal,
-        shadingView,
-        shadingReflection,
-        ao,
-        diffuseSH,
-        specularSH,
-        environmentMap,
-        brdfLUT,
-        environmentSampler,
-        brdfSampler
-    );
+    half3 shaded = shadeGaussian(albedo,
+                                 metallic,
+                                 roughness,
+                                 shadingNormal,
+                                 shadingView,
+                                 shadingReflection,
+                                 ao,
+                                 diffuseSH,
+                                 specularSH,
+                                 environmentMap,
+                                 brdfLUT,
+                                 environmentSampler,
+                                 brdfSampler);
     return half4(shaded * accumulatedAlpha, accumulatedAlpha);
 } else {
     // Coverage and depth handled in postprocess

--- a/MetalSplatter/Resources/SplatProcessing.h
+++ b/MetalSplatter/Resources/SplatProcessing.h
@@ -25,6 +25,8 @@ float3 evaluateSplatSHForSpecular(SplatSHCoefficients coefficients,
                                   ushort coefficientCount,
                                   float3 reflectionDirection);
 
+float3 safeNormalize(float3 value, float3 fallback);
+
 half3 shadeGaussian(half3 albedo,
                     half metallic,
                     half roughness,

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -62,6 +62,8 @@ public class SplatRenderer {
         case normalRaw = 25
         case normalDifference = 26
         case normalDotComparison = 27
+        case sphericalHarmonicsDiffuse = 28
+        case sphericalHarmonicsSpecular = 29
     }
 
     public enum Error: Swift.Error, LocalizedError {

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -64,6 +64,10 @@ extension SplatRenderer.DebugViewMode {
             return "Normal Δ"
         case .normalDotComparison:
             return "N·V Compare"
+        case .sphericalHarmonicsDiffuse:
+            return "SH Diffuse"
+        case .sphericalHarmonicsSpecular:
+            return "SH Specular"
         }
     }
 }


### PR DESCRIPTION
## Summary
- declare `safeNormalize` in the shared header so the render paths can compile
- repair the MultiStage debug-view switch to include the new spherical harmonics modes and restore the difference heatmap case

## Testing
- `swift build` *(fails: no such module 'os' / 'Metal' on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68fffb7d85748321b046c8e47ec7224e