### PR TITLE
Improve calibration anchor visibility

### DIFF
--- a/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/MetalSplatter_SampleApp.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		617E50C92B314C4800F99766 /* PLYIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50C82B314C4800F99766 /* PLYIO */; };
                 617E50CB2B314C4800F99766 /* SplatIO in Frameworks */ = {isa = PBXBuildFile; productRef = 617E50CA2B314C4800F99766 /* SplatIO */; };
                 61F2B3A12F5C123400A1A1A1 /* RendererSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */; };
+                61F2B3B02F5C12AA00A1A1A1 /* ModelCalibration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A12F5C12AA00A1A1A1 /* ModelCalibration.swift */; };
+                61F2B3B12F5C12AA00A1A1A1 /* CalibrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A22F5C12AA00A1A1A1 /* CalibrationStore.swift */; };
+                61F2B3B22F5C12AA00A1A1A1 /* CalibrationAnchorRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A32F5C12AA00A1A1A1 /* CalibrationAnchorRenderer.swift */; };
+                61F2B3B32F5C12AA00A1A1A1 /* CalibrationAnchor.metal in Sources */ = {isa = PBXBuildFile; fileRef = 61F2B3A42F5C12AA00A1A1A1 /* CalibrationAnchor.metal */; };
                 61B9F0A12BC4D50000AA0001 /* PreloadedGaussianModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9F0A02BC4D50000AA0001 /* PreloadedGaussianModel.swift */; };
                 61B9F0A32BC4D50000AA0001 /* GaussianSplats in Resources */ = {isa = PBXBuildFile; fileRef = 61B9F0A22BC4D50000AA0001 /* GaussianSplats */; };
 /* End PBXBuildFile section */
@@ -55,6 +59,10 @@
                 61A1AA042B7C000100A1AA00 /* EnvironmentPrefilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentPrefilter.swift; sourceTree = "<group>"; };
                 61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = EnvironmentPrefilter.metal; sourceTree = "<group>"; };
                 61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererSettings.swift; sourceTree = "<group>"; };
+                61F2B3A12F5C12AA00A1A1A1 /* ModelCalibration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCalibration.swift; sourceTree = "<group>"; };
+                61F2B3A22F5C12AA00A1A1A1 /* CalibrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationStore.swift; sourceTree = "<group>"; };
+                61F2B3A32F5C12AA00A1A1A1 /* CalibrationAnchorRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationAnchorRenderer.swift; sourceTree = "<group>"; };
+                61F2B3A42F5C12AA00A1A1A1 /* CalibrationAnchor.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = CalibrationAnchor.metal; sourceTree = "<group>"; };
                 617E50B02B314BE200F99766 /* MetalSplatter SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MetalSplatter SampleApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
                 61B9F0A02BC4D50000AA0001 /* PreloadedGaussianModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadedGaussianModel.swift; sourceTree = "<group>"; };
                 61B9F0A22BC4D50000AA0001 /* GaussianSplats */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GaussianSplats; path = GaussianSplats; sourceTree = "<group>"; };
@@ -79,6 +87,8 @@
                         isa = PBXGroup;
                         children = (
                                 61791DDB2B4154FB00302B57 /* ModelIdentifier.swift */,
+                                61F2B3A12F5C12AA00A1A1A1 /* ModelCalibration.swift */,
+                                61F2B3A22F5C12AA00A1A1A1 /* CalibrationStore.swift */,
                                 61791DDE2B4154FB00302B57 /* ModelRenderer.swift */,
                                 61791DDC2B4154FB00302B57 /* SampleBoxRenderer+ModelRenderer.swift */,
                                 61791DDA2B4154FB00302B57 /* SplatRenderer+ModelRenderer.swift */,
@@ -109,6 +119,7 @@
                                 61791E142B42294700302B57 /* MetalKitSceneView.swift */,
                                 61791E0C2B41683500302B57 /* VisionSceneRenderer.swift */,
                                 61F2B3A02F5C123400A1A1A1 /* RendererSettings.swift */,
+                                61F2B3A32F5C12AA00A1A1A1 /* CalibrationAnchorRenderer.swift */,
                         );
                         path = Scene;
                         sourceTree = "<group>";
@@ -117,6 +128,7 @@
                         isa = PBXGroup;
                         children = (
                                 61A1AA082B7C000100A1AA00 /* EnvironmentPrefilter.metal */,
+                                61F2B3A42F5C12AA00A1A1A1 /* CalibrationAnchor.metal */,
                         );
                         path = Shaders;
                         sourceTree = "<group>";
@@ -265,6 +277,10 @@
                                 61791E132B416DD700302B57 /* Constants.swift in Sources */,
                                 61791E162B42297B00302B57 /* MetalKitSceneView.swift in Sources */,
                                 610347DC2B46875A00693CE3 /* ContentStageConfiguration.swift in Sources */,
+                                61F2B3B02F5C12AA00A1A1A1 /* ModelCalibration.swift in Sources */,
+                                61F2B3B12F5C12AA00A1A1A1 /* CalibrationStore.swift in Sources */,
+                                61F2B3B22F5C12AA00A1A1A1 /* CalibrationAnchorRenderer.swift in Sources */,
+                                61F2B3B32F5C12AA00A1A1A1 /* CalibrationAnchor.metal in Sources */,
                                 61F2B3A12F5C123400A1A1A1 /* RendererSettings.swift in Sources */,
                         );
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SampleApp/Model/CalibrationStore.swift
+++ b/SampleApp/Model/CalibrationStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+#if os(visionOS)
+
+final class CalibrationStore {
+    private let fileManager: FileManager
+    private let directoryURL: URL
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let baseURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        directoryURL = baseURL.appendingPathComponent("Calibrations", isDirectory: true)
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            try? fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        }
+    }
+
+    func loadCalibration(forKey key: String) -> ModelCalibration? {
+        let url = calibrationURL(for: key)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        return try? decoder.decode(ModelCalibration.self, from: data)
+    }
+
+    func saveCalibration(_ calibration: ModelCalibration, forKey key: String) throws {
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let data = try encoder.encode(calibration)
+        let url = calibrationURL(for: key)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func calibrationURL(for key: String) -> URL {
+        directoryURL.appendingPathComponent("\(key).json")
+    }
+}
+
+#else
+
+final class CalibrationStore {
+    init() {}
+
+    func loadCalibration(forKey key: String) -> ModelCalibration? { nil }
+
+    func saveCalibration(_ calibration: ModelCalibration, forKey key: String) throws {}
+}
+
+#endif

--- a/SampleApp/Model/ModelCalibration.swift
+++ b/SampleApp/Model/ModelCalibration.swift
@@ -1,0 +1,116 @@
+import Foundation
+import simd
+
+#if os(visionOS)
+
+struct ModelCalibration: Codable {
+    struct AnchorMetadata: Codable {
+        var transform: simd_float4x4
+
+        init(transform: simd_float4x4) {
+            self.transform = transform
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case transform
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(Self.flatten(transform), forKey: .transform)
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let values = try container.decode([Float].self, forKey: .transform)
+            guard let matrix = Self.matrix(from: values) else {
+                throw DecodingError.dataCorruptedError(forKey: .transform,
+                                                      in: container,
+                                                      debugDescription: "Expected 16-element array for simd_float4x4")
+            }
+            transform = matrix
+        }
+
+        private static func flatten(_ matrix: simd_float4x4) -> [Float] {
+            let columns = matrix.columns
+            return [
+                columns.0.x, columns.0.y, columns.0.z, columns.0.w,
+                columns.1.x, columns.1.y, columns.1.z, columns.1.w,
+                columns.2.x, columns.2.y, columns.2.z, columns.2.w,
+                columns.3.x, columns.3.y, columns.3.z, columns.3.w
+            ]
+        }
+
+        private static func matrix(from values: [Float]) -> simd_float4x4? {
+            guard values.count == 16 else { return nil }
+            return simd_float4x4(columns: (
+                SIMD4(values[0], values[1], values[2], values[3]),
+                SIMD4(values[4], values[5], values[6], values[7]),
+                SIMD4(values[8], values[9], values[10], values[11]),
+                SIMD4(values[12], values[13], values[14], values[15])
+            ))
+        }
+    }
+
+    var translation: SIMD3<Float>
+    var rotation: simd_quatf
+    var scale: Float
+    var anchor: AnchorMetadata?
+
+    init(translation: SIMD3<Float>,
+         rotation: simd_quatf,
+         scale: Float,
+         anchor: AnchorMetadata? = nil) {
+        self.translation = translation
+        self.rotation = rotation
+        self.scale = scale
+        self.anchor = anchor
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case translation
+        case rotation
+        case scale
+        case anchor
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        translation = try container.decode(SIMD3<Float>.self, forKey: .translation)
+        let rotationVector = try container.decode(SIMD4<Float>.self, forKey: .rotation)
+        rotation = simd_quatf(vector: rotationVector)
+        scale = try container.decode(Float.self, forKey: .scale)
+        anchor = try container.decodeIfPresent(AnchorMetadata.self, forKey: .anchor)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(translation, forKey: .translation)
+        try container.encode(rotation.vector, forKey: .rotation)
+        try container.encode(scale, forKey: .scale)
+        try container.encodeIfPresent(anchor, forKey: .anchor)
+    }
+}
+
+#else
+
+struct ModelCalibration: Codable {
+    struct AnchorMetadata: Codable {}
+
+    var translation: SIMD3<Float>
+    var rotation: simd_quatf
+    var scale: Float
+    var anchor: AnchorMetadata?
+
+    init(translation: SIMD3<Float> = .zero,
+         rotation: simd_quatf = simd_quatf(),
+         scale: Float = 1.0,
+         anchor: AnchorMetadata? = nil) {
+        self.translation = translation
+        self.rotation = rotation
+        self.scale = scale
+        self.anchor = anchor
+    }
+}
+
+#endif

--- a/SampleApp/Model/ModelIdentifier.swift
+++ b/SampleApp/Model/ModelIdentifier.swift
@@ -13,4 +13,20 @@ enum ModelIdentifier: Equatable, Hashable, Codable, CustomStringConvertible {
             return("Sample Box")
         }
     }
+
+    var calibrationKey: String {
+        switch self {
+        case .gaussianSplat(let url):
+            let baseName = url.deletingPathExtension().lastPathComponent
+            let canonicalPath = url.standardizedFileURL.absoluteString
+            var hash: UInt64 = 5381
+            for byte in canonicalPath.utf8 {
+                hash = ((hash << 5) &+ hash) &+ UInt64(byte)
+            }
+            let suffix = String(format: "%016llx", hash)
+            return "\(baseName)-\(suffix)"
+        case .sampleBox:
+            return "sample-box"
+        }
+    }
 }

--- a/SampleApp/Model/ModelRenderer.swift
+++ b/SampleApp/Model/ModelRenderer.swift
@@ -6,6 +6,7 @@ public struct ModelRendererViewportDescriptor {
     var viewport: MTLViewport
     var projectionMatrix: simd_float4x4
     var viewMatrix: simd_float4x4
+    var modelMatrix: simd_float4x4
     var screenSize: SIMD2<Int>
 }
 

--- a/SampleApp/Model/SampleBoxRenderer+ModelRenderer.swift
+++ b/SampleApp/Model/SampleBoxRenderer+ModelRenderer.swift
@@ -12,7 +12,7 @@ extension SampleBoxRenderer: ModelRenderer {
         let remappedViewports = viewports.map { viewport -> ViewportDescriptor in
             ViewportDescriptor(viewport: viewport.viewport,
                                projectionMatrix: viewport.projectionMatrix,
-                               viewMatrix: viewport.viewMatrix,
+                               viewMatrix: viewport.viewMatrix * viewport.modelMatrix,
                                screenSize: viewport.screenSize)
         }
         try render(viewports: remappedViewports,

--- a/SampleApp/Model/SplatRenderer+ModelRenderer.swift
+++ b/SampleApp/Model/SplatRenderer+ModelRenderer.swift
@@ -12,7 +12,7 @@ extension SplatRenderer: ModelRenderer {
         let remappedViewports = viewports.map { viewport -> ViewportDescriptor in
             ViewportDescriptor(viewport: viewport.viewport,
                                projectionMatrix: viewport.projectionMatrix,
-                               viewMatrix: viewport.viewMatrix,
+                               viewMatrix: viewport.viewMatrix * viewport.modelMatrix,
                                screenSize: viewport.screenSize)
         }
         try render(viewports: remappedViewports,

--- a/SampleApp/Scene/CalibrationAnchorRenderer.swift
+++ b/SampleApp/Scene/CalibrationAnchorRenderer.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Metal
+import simd
+
+#if os(visionOS)
+
+final class CalibrationAnchorRenderer {
+    private struct Vertex {
+        var position: SIMD3<Float>
+        var color: SIMD4<Float>
+    }
+
+    private struct Uniforms {
+        var modelViewProjection: simd_float4x4
+    }
+
+    private let pipelineState: MTLRenderPipelineState
+    private let depthState: MTLDepthStencilState
+    private let planeVertexBuffer: MTLBuffer
+    private let axisVertexBuffer: MTLBuffer
+    private let planeVertexCount: Int
+    private let axisVertexCount: Int
+
+    init(device: MTLDevice, colorFormat: MTLPixelFormat, depthFormat: MTLPixelFormat) throws {
+        let library = try device.makeDefaultLibrary()
+        guard let vertexFunction = library.makeFunction(name: "calibrationAnchorVertex"),
+              let fragmentFunction = library.makeFunction(name: "calibrationAnchorFragment") else {
+            throw RendererError.missingShader
+        }
+
+        let vertexDescriptor = MTLVertexDescriptor()
+        vertexDescriptor.attributes[0].format = .float3
+        vertexDescriptor.attributes[0].offset = 0
+        vertexDescriptor.attributes[0].bufferIndex = 0
+        vertexDescriptor.attributes[1].format = .float4
+        vertexDescriptor.attributes[1].offset = MemoryLayout<SIMD3<Float>>.stride
+        vertexDescriptor.attributes[1].bufferIndex = 0
+        vertexDescriptor.layouts[0].stride = MemoryLayout<Vertex>.stride
+        vertexDescriptor.layouts[0].stepFunction = .perVertex
+
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.label = "Calibration Anchor Pipeline"
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        pipelineDescriptor.vertexDescriptor = vertexDescriptor
+        pipelineDescriptor.colorAttachments[0].pixelFormat = colorFormat
+        pipelineDescriptor.colorAttachments[0].isBlendingEnabled = true
+        pipelineDescriptor.colorAttachments[0].rgbBlendOperation = .add
+        pipelineDescriptor.colorAttachments[0].alphaBlendOperation = .add
+        pipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+        pipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+        pipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+        pipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        pipelineDescriptor.depthAttachmentPixelFormat = depthFormat
+
+        pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+
+        let depthDescriptor = MTLDepthStencilDescriptor()
+        depthDescriptor.depthCompareFunction = .always
+        depthDescriptor.isDepthWriteEnabled = false
+        guard let depthState = device.makeDepthStencilState(descriptor: depthDescriptor) else {
+            throw RendererError.missingDepthState
+        }
+        self.depthState = depthState
+
+        let planeColor = SIMD4<Float>(0.65, 0.75, 0.95, 0.35)
+        let planeSize: Float = 0.45
+        let planeVertices: [Vertex] = [
+            Vertex(position: SIMD3<Float>(-planeSize, 0, -planeSize), color: planeColor),
+            Vertex(position: SIMD3<Float>(planeSize, 0, -planeSize), color: planeColor),
+            Vertex(position: SIMD3<Float>(-planeSize, 0, planeSize), color: planeColor),
+            Vertex(position: SIMD3<Float>(planeSize, 0, -planeSize), color: planeColor),
+            Vertex(position: SIMD3<Float>(planeSize, 0, planeSize), color: planeColor),
+            Vertex(position: SIMD3<Float>(-planeSize, 0, planeSize), color: planeColor)
+        ]
+        planeVertexCount = planeVertices.count
+
+        let axisLength: Float = 0.5
+        let axisThicknessColor: Float = 1.0
+        let axisVertices: [Vertex] = [
+            Vertex(position: .zero, color: SIMD4<Float>(axisThicknessColor, 0, 0, 1)),
+            Vertex(position: SIMD3<Float>(axisLength, 0, 0), color: SIMD4<Float>(axisThicknessColor, 0, 0, 1)),
+            Vertex(position: .zero, color: SIMD4<Float>(0, axisThicknessColor, 0, 1)),
+            Vertex(position: SIMD3<Float>(0, axisLength, 0), color: SIMD4<Float>(0, axisThicknessColor, 0, 1)),
+            Vertex(position: .zero, color: SIMD4<Float>(0, 0, axisThicknessColor, 1)),
+            Vertex(position: SIMD3<Float>(0, 0, axisLength), color: SIMD4<Float>(0, 0, axisThicknessColor, 1))
+        ]
+        axisVertexCount = axisVertices.count
+
+        guard let planeBuffer = device.makeBuffer(bytes: planeVertices,
+                                                  length: planeVertices.count * MemoryLayout<Vertex>.stride,
+                                                  options: .storageModeShared) else {
+            throw RendererError.missingBuffer
+        }
+        guard let axisBuffer = device.makeBuffer(bytes: axisVertices,
+                                                 length: axisVertices.count * MemoryLayout<Vertex>.stride,
+                                                 options: .storageModeShared) else {
+            throw RendererError.missingBuffer
+        }
+
+        planeVertexBuffer = planeBuffer
+        axisVertexBuffer = axisBuffer
+    }
+
+    func render(viewports: [ModelRendererViewportDescriptor],
+                colorTexture: MTLTexture,
+                depthTexture: MTLTexture?,
+                commandBuffer: MTLCommandBuffer) {
+        guard !viewports.isEmpty else { return }
+
+        let descriptor = MTLRenderPassDescriptor()
+        descriptor.colorAttachments[0].texture = colorTexture
+        descriptor.colorAttachments[0].loadAction = .load
+        descriptor.colorAttachments[0].storeAction = .store
+        if let depthTexture {
+            descriptor.depthAttachment.texture = depthTexture
+            descriptor.depthAttachment.loadAction = .load
+            descriptor.depthAttachment.storeAction = .store
+        }
+
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else { return }
+        encoder.label = "Calibration Anchor Encoder"
+        encoder.setRenderPipelineState(pipelineState)
+        encoder.setDepthStencilState(depthState)
+        encoder.setCullMode(.none)
+
+        for viewport in viewports {
+            var uniforms = Uniforms(modelViewProjection: viewport.projectionMatrix * viewport.viewMatrix * viewport.modelMatrix)
+            encoder.setViewport(viewport.viewport)
+            encoder.setVertexBytes(&uniforms,
+                                   length: MemoryLayout<Uniforms>.stride,
+                                   index: 1)
+
+            encoder.setVertexBuffer(planeVertexBuffer, offset: 0, index: 0)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: planeVertexCount)
+
+            encoder.setVertexBuffer(axisVertexBuffer, offset: 0, index: 0)
+            encoder.drawPrimitives(type: .line, vertexStart: 0, vertexCount: axisVertexCount)
+        }
+
+        encoder.endEncoding()
+    }
+
+    private enum RendererError: Error {
+        case missingShader
+        case missingBuffer
+        case missingDepthState
+    }
+}
+
+#else
+
+final class CalibrationAnchorRenderer {
+    init(device: MTLDevice, colorFormat: MTLPixelFormat, depthFormat: MTLPixelFormat) throws {}
+
+    func render(viewports: [ModelRendererViewportDescriptor],
+                colorTexture: MTLTexture,
+                depthTexture: MTLTexture?,
+                commandBuffer: MTLCommandBuffer) {}
+}
+
+#endif

--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State private var navigationPath = NavigationPath()
 
     private func openWindow(value: ModelIdentifier) {
+        rendererSettings.activeModel = value
         navigationPath.append(value)
     }
 #elseif os(visionOS)
@@ -21,6 +22,7 @@ struct ContentView: View {
     @State var immersiveSpaceIsShown = false
 
     private func openWindow(value: ModelIdentifier) {
+        rendererSettings.activeModel = value
         Task {
             switch await openImmersiveSpace(value: value) {
             case .opened:
@@ -85,7 +87,9 @@ struct ContentView: View {
                             missingModelAlert = model
                             return
                         }
-                        openWindow(value: ModelIdentifier.gaussianSplat(url))
+                        let identifier = ModelIdentifier.gaussianSplat(url)
+                        rendererSettings.activeModel = identifier
+                        openWindow(value: identifier)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal)
@@ -100,7 +104,9 @@ struct ContentView: View {
             Spacer(minLength: 24)
 
             Button("Show Sample Box") {
-                openWindow(value: ModelIdentifier.sampleBox)
+                let identifier = ModelIdentifier.sampleBox
+                rendererSettings.activeModel = identifier
+                openWindow(value: identifier)
             }
             .padding()
             .buttonStyle(.borderedProminent)
@@ -111,6 +117,32 @@ struct ContentView: View {
             Spacer()
 
 #if os(visionOS)
+            if case .gaussianSplat = rendererSettings.activeModel {
+                switch rendererSettings.calibrationMode {
+                case .idle:
+                    Button("Calibrate") {
+                        rendererSettings.calibrationMode = .running
+                        rendererSettings.calibrationCommands.send(.start)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.bottom)
+                    .disabled(!immersiveSpaceIsShown)
+                case .running:
+                    HStack(spacing: 16) {
+                        Button("Confirm Calibration") {
+                            rendererSettings.calibrationCommands.send(.confirm)
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Cancel") {
+                            rendererSettings.calibrationCommands.send(.cancel)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .padding(.bottom)
+                }
+            }
+
             Button("Dismiss Immersive Space") {
                 Task {
                     await dismissImmersiveSpace()

--- a/SampleApp/Scene/MetalKitSceneRenderer.swift
+++ b/SampleApp/Scene/MetalKitSceneRenderer.swift
@@ -97,20 +97,22 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
 
         let viewport = MTLViewport(originX: 0, originY: 0, width: drawableSize.width, height: drawableSize.height, znear: 0, zfar: 1)
 
+        let modelMatrix = translationMatrix * rotationMatrix * commonUpCalibration
         let viewMatrix: simd_float4x4
 #if os(macOS)
         if let camera = cameraController {
-            viewMatrix = camera.viewMatrix * commonUpCalibration
+            viewMatrix = camera.viewMatrix
         } else {
-            viewMatrix = translationMatrix * rotationMatrix * commonUpCalibration
+            viewMatrix = matrix_identity_float4x4
         }
 #else
-        viewMatrix = translationMatrix * rotationMatrix * commonUpCalibration
+        viewMatrix = matrix_identity_float4x4
 #endif
 
         return ModelRendererViewportDescriptor(viewport: viewport,
                                                projectionMatrix: projectionMatrix,
                                                viewMatrix: viewMatrix,
+                                               modelMatrix: modelMatrix,
                                                screenSize: SIMD2(x: Int(drawableSize.width), y: Int(drawableSize.height)))
     }
 

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -1,8 +1,30 @@
+import Combine
 import Foundation
 import MetalSplatter
 
 final class RendererSettings: ObservableObject {
+    enum CalibrationMode {
+        case idle
+        case running
+    }
+
+    enum CalibrationCommand {
+        case start
+        case confirm
+        case cancel
+    }
+
     @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo
+    @Published var activeModel: ModelIdentifier? {
+        didSet {
+            if oldValue != activeModel {
+                calibrationMode = .idle
+            }
+        }
+    }
+    @Published var calibrationMode: CalibrationMode = .idle
+
+    let calibrationCommands = PassthroughSubject<CalibrationCommand, Never>()
     let primaryDebugModes: [SplatRenderer.DebugViewMode] = [
         .shaded,
         .albedo,

--- a/SampleApp/Scene/Shaders/CalibrationAnchor.metal
+++ b/SampleApp/Scene/Shaders/CalibrationAnchor.metal
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct CalibrationVertexIn {
+    float3 position [[attribute(0)]];
+    float4 color [[attribute(1)]];
+};
+
+struct CalibrationUniforms {
+    float4x4 modelViewProjection;
+};
+
+struct CalibrationVertexOut {
+    float4 position [[position]];
+    float4 color;
+};
+
+vertex CalibrationVertexOut calibrationAnchorVertex(CalibrationVertexIn in [[stage_in]],
+                                                    constant CalibrationUniforms &uniforms [[buffer(1)]]) {
+    CalibrationVertexOut out;
+    out.position = uniforms.modelViewProjection * float4(in.position, 1.0);
+    out.color = in.color;
+    return out;
+}
+
+fragment float4 calibrationAnchorFragment(CalibrationVertexOut in [[stage_in]]) {
+    return in.color;
+}

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -114,10 +114,18 @@ class VisionSceneRenderer {
     private var didAutoCapture: Bool = false
     private var captureNextFrame: Bool = false
     private var lastBrightnessProbeFrame: UInt64 = 0
-    private var rendererSettingsCancellable: AnyCancellable?
+    private var rendererSettingsCancellables: Set<AnyCancellable> = []
     private var debugViewModeStorage: SplatRenderer.DebugViewMode = .albedo
     private let debugViewModeLock = NSLock()
     private var debugViewModeNeedsApply = false
+    private weak var rendererSettings: RendererSettings?
+    private let calibrationStore = CalibrationStore()
+    private var pendingCalibrationCommands: [RendererSettings.CalibrationCommand] = []
+    private let calibrationCommandLock = NSLock()
+    private var isCalibrating = false
+    private var calibrationSnapshot: ModelInteractionState?
+    private var lastDeviceAnchorTransform: simd_float4x4?
+    private let calibrationAnchorRenderer: CalibrationAnchorRenderer?
 
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
@@ -139,6 +147,10 @@ class VisionSceneRenderer {
             environmentPrefilter = nil
         }
 
+        calibrationAnchorRenderer = try? CalibrationAnchorRenderer(device: device,
+                                                                   colorFormat: layerRenderer.configuration.colorFormat,
+                                                                   depthFormat: layerRenderer.configuration.depthFormat)
+
         handUpdateTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
             for await update in self.handTracking.anchorUpdates {
@@ -159,6 +171,22 @@ class VisionSceneRenderer {
         self.model = model
 
         interactionState = ModelInteractionState()
+        calibrationSnapshot = nil
+        isCalibrating = false
+        lastDeviceAnchorTransform = nil
+        calibrationCommandLock.lock()
+        pendingCalibrationCommands.removeAll()
+        calibrationCommandLock.unlock()
+        notifyCalibrationMode(.idle)
+
+        if let model,
+           case .gaussianSplat = model,
+           let key = calibrationKey(for: model),
+           let calibration = calibrationStore.loadCalibration(forKey: key) {
+            interactionState.translation = calibration.translation
+            interactionState.rotation = calibration.rotation
+            interactionState.scale = calibration.scale
+        }
 
         if let splat = modelRenderer as? SplatRenderer {
             try? splat.setEnvironmentMap(nil)
@@ -218,6 +246,7 @@ class VisionSceneRenderer {
         // happens to be a useful default for the most common datasets at the moment.
         let commonUpCalibration = matrix4x4_rotation(radians: .pi, axis: SIMD3<Float>(0, 0, 1))
 
+        let modelMatrix = translationMatrix * rotationMatrix * scaleMatrix * commonUpCalibration
         let simdDeviceAnchor = deviceAnchor?.originFromAnchorTransform ?? matrix_identity_float4x4
 
         return drawable.views.enumerated().map { (i, view) in
@@ -252,7 +281,8 @@ class VisionSceneRenderer {
             }
             return ModelRendererViewportDescriptor(viewport: view.textureMap.viewport,
                                                    projectionMatrix: projMatrixSIMD,
-                                                   viewMatrix: userViewpointMatrix * translationMatrix * rotationMatrix * scaleMatrix * commonUpCalibration,
+                                                   viewMatrix: userViewpointMatrix,
+                                                   modelMatrix: modelMatrix,
                                                    screenSize: screenSize)
         }
     }
@@ -570,12 +600,14 @@ class VisionSceneRenderer {
         let deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: time)
 
         drawable.deviceAnchor = deviceAnchor
+        lastDeviceAnchorTransform = deviceAnchor?.originFromAnchorTransform
 
         let semaphore = inFlightSemaphore
         commandBuffer.addCompletedHandler { (_ commandBuffer)-> Swift.Void in
             semaphore.signal()
         }
 
+        processCalibrationCommandsIfNeeded()
         updateInteractionState()
         updateEnvironmentProbeIfNeeded()
         applyEnvironmentResourcesIfNeeded()
@@ -597,6 +629,16 @@ class VisionSceneRenderer {
             let colorFormatStr = String(describing: cfg.colorFormat)
             let depthFormatStr = String(describing: cfg.depthFormat)
             Self.log.error("Unable to render scene: \(error.localizedDescription). colorFormat=\(colorFormatStr) depthFormat=\(depthFormatStr) views=\(drawable.views.count) frame=\(self.frameCounter)")
+        }
+
+        if isCalibrating,
+           case .gaussianSplat = model,
+           let anchorRenderer = calibrationAnchorRenderer,
+           let colorTexture = drawable.colorTextures.first {
+            anchorRenderer.render(viewports: viewports,
+                                  colorTexture: colorTexture,
+                                  depthTexture: drawable.depthTextures.first,
+                                  commandBuffer: commandBuffer)
         }
 
         if let splatRenderer = modelRenderer as? SplatRenderer {
@@ -630,11 +672,23 @@ class VisionSceneRenderer {
     }
 
     func bindRendererSettings(_ settings: RendererSettings) {
+        rendererSettings = settings
         debugViewMode = settings.debugViewMode
-        rendererSettingsCancellable = settings.$debugViewMode
+        rendererSettingsCancellables.removeAll()
+
+        settings.$debugViewMode
             .sink { [weak self] mode in
                 self?.debugViewMode = mode
             }
+            .store(in: &rendererSettingsCancellables)
+
+        settings.calibrationCommands
+            .sink { [weak self] command in
+                self?.enqueueCalibrationCommand(command)
+            }
+            .store(in: &rendererSettingsCancellables)
+
+        notifyCalibrationMode(isCalibrating ? .running : .idle)
     }
 
     private var debugViewMode: SplatRenderer.DebugViewMode {
@@ -667,6 +721,81 @@ class VisionSceneRenderer {
 
         guard let mode, let splat = modelRenderer as? SplatRenderer else { return }
         splat.debugViewMode = mode
+    }
+
+    private func enqueueCalibrationCommand(_ command: RendererSettings.CalibrationCommand) {
+        calibrationCommandLock.lock()
+        pendingCalibrationCommands.append(command)
+        calibrationCommandLock.unlock()
+    }
+
+    private func processCalibrationCommandsIfNeeded() {
+        calibrationCommandLock.lock()
+        let commands = pendingCalibrationCommands
+        pendingCalibrationCommands.removeAll()
+        calibrationCommandLock.unlock()
+
+        guard !commands.isEmpty else { return }
+
+        for command in commands {
+            switch command {
+            case .start:
+                guard case .gaussianSplat = model, !isCalibrating else { continue }
+                calibrationSnapshot = interactionState
+                isCalibrating = true
+                notifyCalibrationMode(.running)
+            case .confirm:
+                guard isCalibrating else { continue }
+                if let model,
+                   case .gaussianSplat = model,
+                   let key = calibrationKey(for: model) {
+                    let anchorMetadata = lastDeviceAnchorTransform.map { ModelCalibration.AnchorMetadata(transform: $0) }
+                    let calibration = ModelCalibration(translation: interactionState.translation,
+                                                       rotation: interactionState.rotation,
+                                                       scale: interactionState.scale,
+                                                       anchor: anchorMetadata)
+                    do {
+                        try calibrationStore.saveCalibration(calibration, forKey: key)
+                    } catch {
+                        Self.log.error("Failed to save calibration for \(key): \(error.localizedDescription)")
+                    }
+                }
+                isCalibrating = false
+                calibrationSnapshot = nil
+                notifyCalibrationMode(.idle)
+            case .cancel:
+                guard isCalibrating else { continue }
+                if let snapshot = calibrationSnapshot {
+                    interactionState = snapshot
+                }
+                isCalibrating = false
+                calibrationSnapshot = nil
+                notifyCalibrationMode(.idle)
+            }
+        }
+    }
+
+    private func notifyCalibrationMode(_ mode: RendererSettings.CalibrationMode) {
+        guard let settings = rendererSettings else { return }
+        DispatchQueue.main.async {
+            settings.calibrationMode = mode
+        }
+    }
+
+    private func calibrationKey(for model: ModelIdentifier) -> String? {
+        switch model {
+        case .gaussianSplat(let url):
+            let baseName = url.deletingPathExtension().lastPathComponent
+            let canonicalPath = url.standardizedFileURL.absoluteString
+            var hash: UInt64 = 5381
+            for byte in canonicalPath.utf8 {
+                hash = ((hash << 5) &+ hash) &+ UInt64(byte)
+            }
+            let suffix = String(format: "%016llx", hash)
+            return "\(baseName)-\(suffix)"
+        case .sampleBox:
+            return nil
+        }
     }
 
     private func updateEnvironmentProbeIfNeeded() {


### PR DESCRIPTION
## Summary
- add a model-matrix field to viewport descriptors so auxiliary renderers can share the active transform
- render the calibration gizmo with blended colors and a depth-agnostic pipeline so the anchor stays visible while calibrating

## Testing
- not run (visionOS build unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ffedd0c2ac8321b45efe731a44896f