### PR TITLE
Reconstruct splat normals from rotation and scale

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -117,6 +117,22 @@ public class SplatRenderer {
         )
     }
 
+    private static func sanitizeScale(_ scale: SIMD3<Float>, pointIndex: Int) -> SIMD3<Float> {
+        var sanitized = sanitizeVector(scale,
+                                       defaultValue: SIMD3<Float>(repeating: 1),
+                                       field: "scale",
+                                       pointIndex: pointIndex)
+
+        for component in 0..<3 {
+            if sanitized[component] <= .leastNonzeroMagnitude {
+                log.error("Invalid scale component for splat index \(pointIndex, privacy: .public); using default value")
+                sanitized[component] = 1
+            }
+        }
+
+        return sanitized
+    }
+
     private static func sanitizeSphericalHarmonics(_ coefficients: [SIMD3<Float>],
                                                     pointIndex: Int) -> [SIMD3<Float>] {
         coefficients.enumerated().map { index, coefficient in
@@ -187,6 +203,31 @@ public class SplatRenderer {
                     y: Float16(vector.y),
                     z: Float16(vector.z),
                     w: Float16(vector.w))
+    }
+
+    private static func reconstructNormal(rotationMatrix: simd_float3x3,
+                                          scale: SIMD3<Float>,
+                                          fallbackNormal: SIMD3<Float>,
+                                          pointIndex: Int) -> SIMD3<Float> {
+        let scaleComponents = [scale.x, scale.y, scale.z]
+        var smallestIndex = 0
+        var smallestValue = scaleComponents[0]
+        for componentIndex in 1..<scaleComponents.count {
+            if scaleComponents[componentIndex] < smallestValue {
+                smallestIndex = componentIndex
+                smallestValue = scaleComponents[componentIndex]
+            }
+        }
+
+        var reconstructed = rotationMatrix[smallestIndex]
+        let length = simd_length(reconstructed)
+        guard length.isFinite, length > .leastNonzeroMagnitude else {
+            log.error("Failed to reconstruct normal for splat index \(pointIndex, privacy: .public); using serialized value")
+            return fallbackNormal
+        }
+
+        reconstructed /= length
+        return reconstructed
     }
 
     private static func makeFallbackEnvironmentMap(device: MTLDevice) -> MTLTexture {
@@ -1319,7 +1360,9 @@ extension SplatRenderer.Splat {
          normal: SIMD3<Float>,
          pointIndex: Int) {
         let sanitizedRotation = SplatRenderer.sanitizeQuaternion(rotation, pointIndex: pointIndex)
-        let transform = simd_float3x3(sanitizedRotation) * simd_float3x3(diagonal: scale)
+        let sanitizedScale = SplatRenderer.sanitizeScale(scale, pointIndex: pointIndex)
+        let rotationMatrix = simd_float3x3(sanitizedRotation)
+        let transform = rotationMatrix * simd_float3x3(diagonal: sanitizedScale)
         let cov3D = transform * transform.transpose
 
         let sanitizedColor = SplatRenderer.sanitizeColor(color, pointIndex: pointIndex)
@@ -1332,7 +1375,11 @@ extension SplatRenderer.Splat {
                                                                   defaultValue: SplatScenePoint.defaultRoughness,
                                                                   field: "roughness",
                                                                   pointIndex: pointIndex)
-        let sanitizedNormal = SplatRenderer.sanitizeNormal(normal, pointIndex: pointIndex)
+        let serializedNormal = SplatRenderer.sanitizeNormal(normal, pointIndex: pointIndex)
+        let reconstructedNormal = SplatRenderer.reconstructNormal(rotationMatrix: rotationMatrix,
+                                                                  scale: sanitizedScale,
+                                                                  fallbackNormal: serializedNormal,
+                                                                  pointIndex: pointIndex)
 
         let covA = SIMD3<Float>(cov3D[0, 0], cov3D[0, 1], cov3D[0, 2])
         let covB = SIMD3<Float>(cov3D[1, 1], cov3D[1, 2], cov3D[2, 2])
@@ -1355,7 +1402,7 @@ extension SplatRenderer.Splat {
         self.albedo = SplatRenderer.packHalf3(sanitizedAlbedo)
         self.metallic = Float16(sanitizedMetallic)
         self.roughness = Float16(sanitizedRoughness)
-        self.normal = SplatRenderer.packHalf3(sanitizedNormal)
+        self.normal = SplatRenderer.packHalf3(reconstructedNormal)
         self.rotation = SplatRenderer.packHalf4(sanitizedRotation.vector)
     }
 }

--- a/MetalSplatter/Tests/SplatRendererTests.swift
+++ b/MetalSplatter/Tests/SplatRendererTests.swift
@@ -7,27 +7,51 @@ import XCTest
 import SplatIO
 
 final class SplatRendererPackingTests: XCTestCase {
+    private func expectedGIRNormal(rotation: simd_quatf, scale: SIMD3<Float>) -> SIMD3<Float> {
+        let rotationMatrix = simd_float3x3(rotation)
+        let scaleComponents = [scale.x, scale.y, scale.z]
+        var smallestIndex = 0
+        var smallestValue = scaleComponents[0]
+        for index in 1..<scaleComponents.count {
+            if scaleComponents[index] < smallestValue {
+                smallestIndex = index
+                smallestValue = scaleComponents[index]
+            }
+        }
+
+        var column = rotationMatrix[smallestIndex]
+        let length = simd_length(column)
+        if length > .leastNonzeroMagnitude, length.isFinite {
+            column /= length
+        }
+        return column
+    }
+
     func testSplatPacksMaterialProperties() {
+        let rotation = simd_quatf(angle: .pi / 2, axis: SIMD3<Float>(0, 0, 1))
+        let scale = SIMD3<Float>(0.25, 1.0, 0.5)
         let point = SplatScenePoint(position: SIMD3<Float>(1, 2, 3),
                                     color: .linearFloat(SIMD3<Float>(0.25, 0.5, 0.75)),
                                     opacity: .linearFloat(0.8),
-                                    scale: .linearFloat(SIMD3<Float>(repeating: 1)),
-                                    rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)),
+                                    scale: .linearFloat(scale),
+                                    rotation: rotation,
                                     albedo: SIMD3<Float>(0.2, 0.4, 0.6),
                                     metallic: 0.3,
                                     roughness: 0.7,
-                                    normal: SIMD3<Float>(0, 1, 0))
+                                    normal: SIMD3<Float>(0, 0, 1))
 
         let splat = SplatRenderer.Splat(point, index: 0)
+
+        let expectedNormal = expectedGIRNormal(rotation: rotation, scale: scale)
 
         XCTAssertEqual(Float(splat.albedo.x), 0.2, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.albedo.y), 0.4, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.albedo.z), 0.6, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.metallic), 0.3, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.roughness), 0.7, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.x), 0, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.y), 1, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.z), 0, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.x), expectedNormal.x, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.y), expectedNormal.y, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.z), expectedNormal.z, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.a), 0.8, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.rotation.x), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.rotation.y), 0, accuracy: 1e-3)
@@ -48,14 +72,16 @@ final class SplatRendererPackingTests: XCTestCase {
 
         let splat = SplatRenderer.Splat(point, index: 5)
 
+        let expectedNormal = expectedGIRNormal(rotation: point.rotation, scale: point.scale.asLinearFloat)
+
         XCTAssertEqual(Float(splat.albedo.x), SplatScenePoint.defaultAlbedo.x, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.albedo.y), SplatScenePoint.defaultAlbedo.y, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.albedo.z), SplatScenePoint.defaultAlbedo.z, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.metallic), SplatScenePoint.defaultMetallic, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.roughness), SplatScenePoint.defaultRoughness, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.x), SplatScenePoint.defaultNormal.x, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.y), SplatScenePoint.defaultNormal.y, accuracy: 1e-3)
-        XCTAssertEqual(Float(splat.normal.z), SplatScenePoint.defaultNormal.z, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.x), expectedNormal.x, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.y), expectedNormal.y, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.z), expectedNormal.z, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.x), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.y), 0, accuracy: 1e-3)
         XCTAssertEqual(Float(splat.color.z), 0, accuracy: 1e-3)


### PR DESCRIPTION
## Summary
- sanitize splat scale data and reconstruct GIR-style normals from the rotation matrix
- pack the reconstructed normal into splats with a fallback to serialized data when reconstruction fails
- update renderer unit tests to assert that normals follow the GIR reconstruction rules

## Testing
- swift test *(fails: missing `os` and `Metal` modules in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_69003acf6470832182b7873b48a2fba6