### PR TITLE
Respect serialized normals for GIR splats

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -1347,6 +1347,7 @@ extension SplatRenderer.Splat {
                   metallic: normalized.metallic,
                   roughness: normalized.roughness,
                   normal: normalized.normal,
+                  hasSerializedNormal: normalized.hasSerializedNormal,
                   pointIndex: index)
     }
 
@@ -1358,6 +1359,7 @@ extension SplatRenderer.Splat {
          metallic: Float,
          roughness: Float,
          normal: SIMD3<Float>,
+         hasSerializedNormal: Bool,
          pointIndex: Int) {
         let sanitizedRotation = SplatRenderer.sanitizeQuaternion(rotation, pointIndex: pointIndex)
         let sanitizedScale = SplatRenderer.sanitizeScale(scale, pointIndex: pointIndex)
@@ -1376,10 +1378,15 @@ extension SplatRenderer.Splat {
                                                                   field: "roughness",
                                                                   pointIndex: pointIndex)
         let serializedNormal = SplatRenderer.sanitizeNormal(normal, pointIndex: pointIndex)
-        let reconstructedNormal = SplatRenderer.reconstructNormal(rotationMatrix: rotationMatrix,
+        let reconstructedNormal: SIMD3<Float>
+        if hasSerializedNormal {
+            reconstructedNormal = serializedNormal
+        } else {
+            reconstructedNormal = SplatRenderer.reconstructNormal(rotationMatrix: rotationMatrix,
                                                                   scale: sanitizedScale,
                                                                   fallbackNormal: serializedNormal,
                                                                   pointIndex: pointIndex)
+        }
 
         let covA = SIMD3<Float>(cov3D[0, 0], cov3D[0, 1], cov3D[0, 2])
         let covB = SIMD3<Float>(cov3D[1, 1], cov3D[1, 2], cov3D[2, 2])

--- a/MetalSplatter/Tests/SplatRendererTests.swift
+++ b/MetalSplatter/Tests/SplatRendererTests.swift
@@ -59,6 +59,28 @@ final class SplatRendererPackingTests: XCTestCase {
         XCTAssertEqual(Float(splat.rotation.w), 1, accuracy: 1e-3)
     }
 
+    func testSerializedNormalOverridesReconstruction() {
+        let rotation = simd_quatf(angle: .pi / 3, axis: SIMD3<Float>(0, 1, 0))
+        let scale = SIMD3<Float>(0.1, 0.2, 0.3)
+        let providedNormal = simd_normalize(SIMD3<Float>(1, 1, 0))
+        let point = SplatScenePoint(position: SIMD3<Float>(1, 2, 3),
+                                    color: .linearFloat(SIMD3<Float>(repeating: 0.25)),
+                                    opacity: .linearFloat(0.6),
+                                    scale: .linearFloat(scale),
+                                    rotation: rotation,
+                                    albedo: SIMD3<Float>(repeating: 0.5),
+                                    metallic: 0.1,
+                                    roughness: 0.2,
+                                    normal: providedNormal,
+                                    normalWasProvided: true)
+
+        let splat = SplatRenderer.Splat(point, index: 1)
+
+        XCTAssertEqual(Float(splat.normal.x), providedNormal.x, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.y), providedNormal.y, accuracy: 1e-3)
+        XCTAssertEqual(Float(splat.normal.z), providedNormal.z, accuracy: 1e-3)
+    }
+
     func testInvalidMaterialValuesFallBackToDefaults() {
         var point = SplatScenePoint(position: .zero,
                                     color: .linearFloat(SIMD3<Float>(Float.nan, Float.nan, Float.nan)),

--- a/SplatIO/Sources/SplatPLYSceneReader.swift
+++ b/SplatIO/Sources/SplatPLYSceneReader.swift
@@ -324,9 +324,9 @@ private struct ElementInputMapping {
         result.rotation.imag.z = try element.float32Value(forPropertyIndex: rotation3PropertyIndex)
 
         if let normalPropertyIndices {
-            result.setNormal(try element.normalizedVector(for: normalPropertyIndices))
+            result.setNormal(try element.normalizedVector(for: normalPropertyIndices), isProvided: true)
         } else {
-            result.setNormal(SplatScenePoint.defaultNormal)
+            result.setNormal(SplatScenePoint.defaultNormal, isProvided: false)
         }
 
         if let albedoPropertyIndices {

--- a/SplatIO/Sources/SplatScenePoint.swift
+++ b/SplatIO/Sources/SplatScenePoint.swift
@@ -173,6 +173,7 @@ public struct SplatScenePoint {
     public var metallic: Float
     public var roughness: Float
     public var normal: SIMD3<Float>
+    public var hasSerializedNormal: Bool
 
     public init(position: SIMD3<Float>,
                 color: Color,
@@ -182,7 +183,8 @@ public struct SplatScenePoint {
                 albedo: SIMD3<Float> = Self.defaultAlbedo,
                 metallic: Float = Self.defaultMetallic,
                 roughness: Float = Self.defaultRoughness,
-                normal: SIMD3<Float> = Self.defaultNormal) {
+                normal: SIMD3<Float> = Self.defaultNormal,
+                normalWasProvided: Bool = false) {
         self.position = position
         self.color = color
         self.opacity = opacity
@@ -192,6 +194,7 @@ public struct SplatScenePoint {
         self.metallic = metallic.clamped(to: 0...1)
         self.roughness = roughness.clamped(to: 0...1)
         self.normal = normal.normalizedOrDefault(Self.defaultNormal)
+        self.hasSerializedNormal = normalWasProvided
     }
 
     public var linearNormalized: SplatScenePoint {
@@ -203,7 +206,8 @@ public struct SplatScenePoint {
                         albedo: albedo.clamped01(),
                         metallic: metallic.clamped(to: 0...1),
                         roughness: roughness.clamped(to: 0...1),
-                        normal: normal.normalizedOrDefault(Self.defaultNormal))
+                        normal: normal.normalizedOrDefault(Self.defaultNormal),
+                        normalWasProvided: hasSerializedNormal)
     }
 
     public mutating func setAlbedo(_ input: AlbedoInput) {
@@ -242,8 +246,9 @@ public struct SplatScenePoint {
         }
     }
 
-    public mutating func setNormal(_ newNormal: SIMD3<Float>) {
+    public mutating func setNormal(_ newNormal: SIMD3<Float>, isProvided: Bool = true) {
         normal = newNormal.normalizedOrDefault(Self.defaultNormal)
+        hasSerializedNormal = isProvided
     }
 }
 

--- a/SplatIO/Tests/SplatIOTests.swift
+++ b/SplatIO/Tests/SplatIOTests.swift
@@ -215,6 +215,49 @@ final class SplatIOTests: XCTestCase {
         XCTAssertEqual(point.normal.x, 0.0, accuracy: 1e-5)
         XCTAssertEqual(point.normal.y, 0.0, accuracy: 1e-5)
         XCTAssertEqual(point.normal.z, 1.0, accuracy: 1e-5)
+        XCTAssertTrue(point.hasSerializedNormal)
+    }
+
+    func testPLYMaterialFloat32WithoutNormalsFallsBack() throws {
+        let ascii = """
+        ply
+        format ascii 1.0
+        element vertex 1
+        property float x
+        property float y
+        property float z
+        property float f_dc_0
+        property float f_dc_1
+        property float f_dc_2
+        property float opacity
+        property float scale_0
+        property float scale_1
+        property float scale_2
+        property float rot_0
+        property float rot_1
+        property float rot_2
+        property float rot_3
+        property float albedo_r
+        property float albedo_g
+        property float albedo_b
+        property float metallic
+        property float roughness
+        end_header
+        0 0 0 0 0 0 0 1 1 1 0 0 0 0 0.25 0.5 0.75 0.2 0.8
+        """
+
+        let points = try readPoints(fromASCII: ascii)
+        XCTAssertEqual(points.count, 1)
+        let point = try XCTUnwrap(points.first)
+        XCTAssertEqual(point.albedo.x, 0.25, accuracy: 1e-5)
+        XCTAssertEqual(point.albedo.y, 0.5, accuracy: 1e-5)
+        XCTAssertEqual(point.albedo.z, 0.75, accuracy: 1e-5)
+        XCTAssertEqual(point.metallic, 0.2, accuracy: 1e-5)
+        XCTAssertEqual(point.roughness, 0.8, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.x, 0.0, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.y, 0.0, accuracy: 1e-5)
+        XCTAssertEqual(point.normal.z, 1.0, accuracy: 1e-5)
+        XCTAssertFalse(point.hasSerializedNormal)
     }
 
     func testPLYMaterialFloat32GIRRaw() throws {
@@ -259,6 +302,7 @@ final class SplatIOTests: XCTestCase {
         XCTAssertEqual(point.normal.x, 0.0, accuracy: 1e-5)
         XCTAssertEqual(point.normal.y, 0.0, accuracy: 1e-5)
         XCTAssertEqual(point.normal.z, 1.0, accuracy: 1e-5)
+        XCTAssertTrue(point.hasSerializedNormal)
     }
 
     func testPLYMaterialFloat32Times256() throws {
@@ -304,6 +348,7 @@ final class SplatIOTests: XCTestCase {
         XCTAssertEqual(point.normal.x, expectedNormal.x, accuracy: 1e-5)
         XCTAssertEqual(point.normal.y, expectedNormal.y, accuracy: 1e-5)
         XCTAssertEqual(point.normal.z, expectedNormal.z, accuracy: 1e-5)
+        XCTAssertTrue(point.hasSerializedNormal)
     }
 
     func testPLYMaterialUInt8() throws {


### PR DESCRIPTION
## Summary
- track whether PLY files provided explicit normals and preserve that through normalization
- prefer serialized normals when present during splat packing, with new coverage for provided normals
- validate normal provenance in PLY parsing, including a missing-normal fallback test

## Testing
- swift test *(fails: missing `os` and `Metal` modules in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da8795e58832191e9e54ffd332a14)