### PR TITLE
Add reset support for visionOS calibration

### DIFF
--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -120,13 +120,21 @@ struct ContentView: View {
             if case .gaussianSplat = rendererSettings.activeModel {
                 switch rendererSettings.calibrationMode {
                 case .idle:
-                    Button("Calibrate") {
-                        rendererSettings.calibrationMode = .running
-                        rendererSettings.calibrationCommands.send(.start)
+                    HStack(spacing: 16) {
+                        Button("Calibrate") {
+                            rendererSettings.calibrationMode = .running
+                            rendererSettings.calibrationCommands.send(.start)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!immersiveSpaceIsShown)
+
+                        Button("Reset") {
+                            rendererSettings.calibrationCommands.send(.reset)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(!immersiveSpaceIsShown)
                     }
-                    .buttonStyle(.borderedProminent)
                     .padding(.bottom)
-                    .disabled(!immersiveSpaceIsShown)
                 case .running:
                     HStack(spacing: 16) {
                         Button("Confirm Calibration") {

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -12,6 +12,7 @@ final class RendererSettings: ObservableObject {
         case start
         case confirm
         case cancel
+        case reset
     }
 
     @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -120,6 +120,7 @@ class VisionSceneRenderer {
     private var debugViewModeNeedsApply = false
     private weak var rendererSettings: RendererSettings?
     private let calibrationStore = CalibrationStore()
+    private var lastConfirmedCalibration: ModelCalibration?
     private var pendingCalibrationCommands: [RendererSettings.CalibrationCommand] = []
     private let calibrationCommandLock = NSLock()
     private var isCalibrating = false
@@ -174,6 +175,7 @@ class VisionSceneRenderer {
         calibrationSnapshot = nil
         isCalibrating = false
         lastDeviceAnchorTransform = nil
+        lastConfirmedCalibration = nil
         calibrationCommandLock.lock()
         pendingCalibrationCommands.removeAll()
         calibrationCommandLock.unlock()
@@ -183,6 +185,7 @@ class VisionSceneRenderer {
            case .gaussianSplat = model,
            let key = calibrationKey(for: model),
            let calibration = calibrationStore.loadCalibration(forKey: key) {
+            lastConfirmedCalibration = calibration
             interactionState.translation = calibration.translation
             interactionState.rotation = calibration.rotation
             interactionState.scale = calibration.scale
@@ -754,6 +757,7 @@ class VisionSceneRenderer {
                                                        rotation: interactionState.rotation,
                                                        scale: interactionState.scale,
                                                        anchor: anchorMetadata)
+                    lastConfirmedCalibration = calibration
                     do {
                         try calibrationStore.saveCalibration(calibration, forKey: key)
                     } catch {
@@ -771,6 +775,12 @@ class VisionSceneRenderer {
                 isCalibrating = false
                 calibrationSnapshot = nil
                 notifyCalibrationMode(.idle)
+            case .reset:
+                guard !isCalibrating,
+                      let calibration = lastConfirmedCalibration else { continue }
+                interactionState.translation = calibration.translation
+                interactionState.rotation = calibration.rotation
+                interactionState.scale = calibration.scale
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a reset calibration command and expose it in the visionOS UI
- track last confirmed calibrations and reapply them when reset is requested
- ensure calibration state stays unchanged when issuing resets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee7a2c3d083218579ea3ec57ed470)