### PR TITLE
Fix missing closing brace in resolveFragmentValues

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -386,6 +386,7 @@ if (DEBUG_VIEW_VALUE == 28) {
     // Coverage and depth handled in postprocess
     return half4(0);
 }
+}
 
 fragment FragmentOut postprocessFragmentShader(FragmentValues fragmentValues [[imageblock_data]],
                                                texturecube<half> environmentMap [[texture(0)]],


### PR DESCRIPTION
## Summary
- add the missing closing brace to resolveFragmentValues to keep postprocess fragment shaders at top level

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0b1cf80883219db8716ca6c23b14)