### PR TITLE
Add UI controls for normal debug visualizations

### DIFF
--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -67,6 +67,14 @@ struct ContentView: View {
             .pickerStyle(.segmented)
             .padding(.horizontal)
 
+            Picker("Normal Debug View", selection: $rendererSettings.debugViewMode) {
+                ForEach(rendererSettings.normalDebugModes, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+
             // Read a scene file from disk
             Button("Read Scene File") {
                 isPickingFile = true

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -13,6 +13,13 @@ final class RendererSettings: ObservableObject {
         .depth,
         .coverage
     ]
+
+    let normalDebugModes: [SplatRenderer.DebugViewMode] = [
+        .normalSweep,
+        .normalRaw,
+        .normalDifference,
+        .normalDotComparison
+    ]
 }
 
 extension SplatRenderer.DebugViewMode {
@@ -57,13 +64,13 @@ extension SplatRenderer.DebugViewMode {
         case .metallicSweep:
             return "Metallic (Alt)"
         case .normalSweep:
-            return "Normal (Alt)"
+            return "Decoded Normal"
         case .normalRaw:
-            return "Normal Raw"
+            return "Raw Normal"
         case .normalDifference:
-            return "Normal Δ"
+            return "Abs(Decoded - Raw)"
         case .normalDotComparison:
-            return "N·V Compare"
+            return "N·V Vergleich"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated picker in the main UI for normal debug visualizations
- expose decoded, raw, difference, and N·V comparison normal debug modes with clearer labels

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2caa86588321846e05cb275a884f)