### PR TITLE
Expose additional normal debug view options in UI

### DIFF
--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -60,11 +60,11 @@ struct ContentView: View {
 
             // Debug view selector
             Picker("Debug View", selection: $rendererSettings.debugViewMode) {
-                ForEach(rendererSettings.primaryDebugModes, id: \.self) { mode in
+                ForEach(rendererSettings.allDebugModes, id: \.self) { mode in
                     Text(mode.displayName).tag(mode)
                 }
             }
-            .pickerStyle(.segmented)
+            .pickerStyle(.menu)
             .padding(.horizontal)
 
             // Read a scene file from disk

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -13,6 +13,17 @@ final class RendererSettings: ObservableObject {
         .depth,
         .coverage
     ]
+
+    let normalDebugModes: [SplatRenderer.DebugViewMode] = [
+        .normalSweep,
+        .normalRaw,
+        .normalDifference,
+        .normalDotComparison
+    ]
+
+    var allDebugModes: [SplatRenderer.DebugViewMode] {
+        primaryDebugModes + normalDebugModes
+    }
 }
 
 extension SplatRenderer.DebugViewMode {
@@ -57,13 +68,13 @@ extension SplatRenderer.DebugViewMode {
         case .metallicSweep:
             return "Metallic (Alt)"
         case .normalSweep:
-            return "Normal (Alt)"
+            return "Decoded Normal"
         case .normalRaw:
-            return "Normal Raw"
+            return "Raw Normal"
         case .normalDifference:
-            return "Normal Δ"
+            return "|Decoded - Raw|"
         case .normalDotComparison:
-            return "N·V Compare"
+            return "N·V (decoded vs raw)"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add decoded/raw normal debug view modes to the main picker
- update display names to match the new normal debug options
- switch the debug view picker to a menu style to accommodate the full list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2fce284483218edae9f280e1d580)