### PR TITLE
Add runtime toggle for rotating normals by quaternion

### DIFF
--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -49,6 +49,8 @@ typedef struct
     uint indexedSplatCount;
     uint shCoefficientCount;
     uint useSHMask;
+    uint rotateNormalsByQuaternion;
+    uint3 _paddingRotateNormals;
 } Uniforms;
 
 typedef struct

--- a/MetalSplatter/Resources/SplatProcessing.metal
+++ b/MetalSplatter/Resources/SplatProcessing.metal
@@ -1,7 +1,3 @@
-#ifndef NORMAL_ROTATE_BY_QUAT
-#define NORMAL_ROTATE_BY_QUAT 1 // set to 0 to bypass per-splat quaternion rotation for normals
-#endif
-
 #import "SplatProcessing.h"
 
 float4 normalizeQuaternion(float4 quaternion) {
@@ -346,9 +342,13 @@ FragmentIn splatVertex(Splat splat,
     // Base normal straight from the splat (sanitized)
     float3 baseNormal = safeNormalize(float3(splat.normal), float3(0, 0, 1));
 
-    // Rotate normal by the splat's quaternion (default behavior)
-    float4 rotation = float4(splat.rotation);
-    float3 n = safeNormalize(rotateVectorByQuaternion(rotation, baseNormal), float3(0, 0, 1));
+    float3 n;
+    if (uniforms.rotateNormalsByQuaternion != 0) {
+        float4 rotation = float4(splat.rotation);
+        n = safeNormalize(rotateVectorByQuaternion(rotation, baseNormal), float3(0, 0, 1));
+    } else {
+        n = baseNormal;
+    }
 
     out.normal = half3(n);
     out.worldPosition = worldPosition;

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -299,6 +299,8 @@ public class SplatRenderer {
         var indexedSplatCount: UInt32
         var shCoefficientCount: UInt32
         var useSHMask: UInt32
+        var rotateNormalsByQuaternion: UInt32
+        var rotateNormalsPadding: SIMD3<UInt32> = .zero
     }
 
     // Keep in sync with Shaders.metal : UniformsArray
@@ -425,6 +427,8 @@ public class SplatRenderer {
             resetPipelineStates()
         }
     }
+
+    public var rotateNormalsByQuaternion: Bool = true
 
     private var writeDepth: Bool {
         depthFormat != .invalid
@@ -1016,7 +1020,8 @@ public class SplatRenderer {
                                     splatCount: splatCount,
                                     indexedSplatCount: indexedSplatCount,
                                     shCoefficientCount: shCoefficientCount,
-                                    useSHMask: shMask)
+                                    useSHMask: shMask,
+                                    rotateNormalsByQuaternion: rotateNormalsByQuaternion ? 1 : 0)
             self.uniforms.pointee.setUniforms(index: i, uniforms)
         }
 

--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -67,6 +67,9 @@ struct ContentView: View {
             .pickerStyle(.segmented)
             .padding(.horizontal)
 
+            Toggle("Rotate Normals by Quaternion", isOn: $rendererSettings.rotateNormalsByQuaternion)
+                .padding(.horizontal)
+
             // Read a scene file from disk
             Button("Read Scene File") {
                 isPickingFile = true

--- a/SampleApp/Scene/MetalKitSceneRenderer.swift
+++ b/SampleApp/Scene/MetalKitSceneRenderer.swift
@@ -38,6 +38,13 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
         }
     }
 
+    var rotateNormalsByQuaternion = true {
+        didSet {
+            guard oldValue != rotateNormalsByQuaternion else { return }
+            applyRotateNormalsByQuaternion()
+        }
+    }
+
     init?(_ metalKitView: MTKView, camera: CameraController? = nil) {
         self.device = metalKitView.device!
         guard let queue = self.device.makeCommandQueue() else { return nil }
@@ -69,6 +76,7 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
                                                 maxSimultaneousRenders: Constants.maxSimultaneousRenders)
             try await splat.read(from: url)
             splat.debugViewMode = debugViewMode
+            splat.rotateNormalsByQuaternion = rotateNormalsByQuaternion
             modelRenderer = splat
         case .sampleBox:
             modelRenderer = try! await SampleBoxRenderer(device: device,
@@ -172,6 +180,11 @@ class MetalKitSceneRenderer: NSObject, MTKViewDelegate {
     private func applyDebugViewMode() {
         guard let splat = modelRenderer as? SplatRenderer else { return }
         splat.debugViewMode = debugViewMode
+    }
+
+    private func applyRotateNormalsByQuaternion() {
+        guard let splat = modelRenderer as? SplatRenderer else { return }
+        splat.rotateNormalsByQuaternion = rotateNormalsByQuaternion
     }
 }
 

--- a/SampleApp/Scene/MetalKitSceneView.swift
+++ b/SampleApp/Scene/MetalKitSceneView.swift
@@ -56,6 +56,7 @@ struct MetalKitSceneView: ViewRepresentable {
         metalKitView.delegate = renderer
 
         renderer?.debugViewMode = rendererSettings.debugViewMode
+        renderer?.rotateNormalsByQuaternion = rendererSettings.rotateNormalsByQuaternion
 
         Task {
             do {
@@ -81,6 +82,7 @@ struct MetalKitSceneView: ViewRepresentable {
     private func updateView(_ coordinator: Coordinator) {
         guard let renderer = coordinator.renderer else { return }
         renderer.debugViewMode = rendererSettings.debugViewMode
+        renderer.rotateNormalsByQuaternion = rendererSettings.rotateNormalsByQuaternion
         Task {
             do {
                 try await renderer.load(modelIdentifier)

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -3,6 +3,7 @@ import MetalSplatter
 
 final class RendererSettings: ObservableObject {
     @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo
+    @Published var rotateNormalsByQuaternion: Bool = true
     let primaryDebugModes: [SplatRenderer.DebugViewMode] = [
         .shaded,
         .albedo,

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -114,10 +114,13 @@ class VisionSceneRenderer {
     private var didAutoCapture: Bool = false
     private var captureNextFrame: Bool = false
     private var lastBrightnessProbeFrame: UInt64 = 0
-    private var rendererSettingsCancellable: AnyCancellable?
+    private var rendererSettingsCancellables = Set<AnyCancellable>()
     private var debugViewModeStorage: SplatRenderer.DebugViewMode = .albedo
     private let debugViewModeLock = NSLock()
     private var debugViewModeNeedsApply = false
+    private var rotateNormalsByQuaternionStorage: Bool = true
+    private let rotateNormalsByQuaternionLock = NSLock()
+    private var rotateNormalsByQuaternionNeedsApply = false
 
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
@@ -175,6 +178,7 @@ class VisionSceneRenderer {
                                           maxSimultaneousRenders: Constants.maxSimultaneousRenders)
             try await splat.read(from: url)
             splat.debugViewMode = debugViewMode
+            splat.rotateNormalsByQuaternion = rotateNormalsByQuaternion
             modelRenderer = splat
             if environmentPrefilterResult != nil {
                 environmentResourcesDirty = true
@@ -623,6 +627,7 @@ class VisionSceneRenderer {
             } else {
                 autoreleasepool {
                     self.applyDebugViewModeIfNeeded()
+                    self.applyRotateNormalsByQuaternionIfNeeded()
                     self.renderFrame()
                 }
             }
@@ -631,10 +636,21 @@ class VisionSceneRenderer {
 
     func bindRendererSettings(_ settings: RendererSettings) {
         debugViewMode = settings.debugViewMode
-        rendererSettingsCancellable = settings.$debugViewMode
+        rotateNormalsByQuaternion = settings.rotateNormalsByQuaternion
+
+        rendererSettingsCancellables.removeAll()
+
+        settings.$debugViewMode
             .sink { [weak self] mode in
                 self?.debugViewMode = mode
             }
+            .store(in: &rendererSettingsCancellables)
+
+        settings.$rotateNormalsByQuaternion
+            .sink { [weak self] shouldRotate in
+                self?.rotateNormalsByQuaternion = shouldRotate
+            }
+            .store(in: &rendererSettingsCancellables)
     }
 
     private var debugViewMode: SplatRenderer.DebugViewMode {
@@ -654,6 +670,23 @@ class VisionSceneRenderer {
         }
     }
 
+    private var rotateNormalsByQuaternion: Bool {
+        get {
+            rotateNormalsByQuaternionLock.lock()
+            defer { rotateNormalsByQuaternionLock.unlock() }
+            return rotateNormalsByQuaternionStorage
+        }
+        set {
+            rotateNormalsByQuaternionLock.lock()
+            let didChange = rotateNormalsByQuaternionStorage != newValue
+            rotateNormalsByQuaternionStorage = newValue
+            if didChange {
+                rotateNormalsByQuaternionNeedsApply = true
+            }
+            rotateNormalsByQuaternionLock.unlock()
+        }
+    }
+
     private func applyDebugViewModeIfNeeded() {
         let mode: SplatRenderer.DebugViewMode?
         debugViewModeLock.lock()
@@ -667,6 +700,21 @@ class VisionSceneRenderer {
 
         guard let mode, let splat = modelRenderer as? SplatRenderer else { return }
         splat.debugViewMode = mode
+    }
+
+    private func applyRotateNormalsByQuaternionIfNeeded() {
+        let shouldRotate: Bool?
+        rotateNormalsByQuaternionLock.lock()
+        if rotateNormalsByQuaternionNeedsApply {
+            rotateNormalsByQuaternionNeedsApply = false
+            shouldRotate = rotateNormalsByQuaternionStorage
+        } else {
+            shouldRotate = nil
+        }
+        rotateNormalsByQuaternionLock.unlock()
+
+        guard let shouldRotate, let splat = modelRenderer as? SplatRenderer else { return }
+        splat.rotateNormalsByQuaternion = shouldRotate
     }
 
     private func updateEnvironmentProbeIfNeeded() {


### PR DESCRIPTION
## Summary
- add a renderer setting and UI toggle to control quaternion-based normal rotation
- propagate the setting through MetalKit/Vision renderers and SplatRenderer uniforms
- switch the shader normal calculation to use the runtime flag instead of a compile-time macro

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f354bf14c8321bc8d414a25e1c793)