### PR TITLE
Add spherical harmonics debug modes

### DIFF
--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -62,6 +62,8 @@ public class SplatRenderer {
         case normalRaw = 25
         case normalDifference = 26
         case normalDotComparison = 27
+        case diffuseSphericalHarmonics = 28
+        case specularSphericalHarmonics = 29
     }
 
     public enum Error: Swift.Error, LocalizedError {

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -21,8 +21,13 @@ final class RendererSettings: ObservableObject {
         .normalDotComparison
     ]
 
+    let sphericalHarmonicsDebugModes: [SplatRenderer.DebugViewMode] = [
+        .diffuseSphericalHarmonics,
+        .specularSphericalHarmonics
+    ]
+
     var allDebugModes: [SplatRenderer.DebugViewMode] {
-        primaryDebugModes + normalDebugModes
+        primaryDebugModes + normalDebugModes + sphericalHarmonicsDebugModes
     }
 }
 
@@ -75,6 +80,10 @@ extension SplatRenderer.DebugViewMode {
             return "|Decoded - Raw|"
         case .normalDotComparison:
             return "N·V (decoded vs raw)"
+        case .diffuseSphericalHarmonics:
+            return "Diffuse SH"
+        case .specularSphericalHarmonics:
+            return "Specular SH"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add diffuse and specular spherical harmonics debug view modes aligned with shader constants
- expose user-facing labels for the new modes and include them in the debug mode picker options

## Testing
- swift test *(fails in this Linux environment: missing Metal/os modules during build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f36fce48c8321881220a2bcc13752)