### PR TITLE
Add spherical harmonics debug instrumentation

### DIFF
--- a/MetalSplatter/Resources/MultiStageRenderPath.metal
+++ b/MetalSplatter/Resources/MultiStageRenderPath.metal
@@ -110,7 +110,8 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
                                                      ushort viewIndex [[render_target_array_index]],
                                                      FragmentValues previousFragmentValues [[imageblock_data]],
                                                      constant SplatSHCoefficients* splatSHArray [[ buffer(BufferIndexSphericalHarmonics) ]],
-                                                     constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
+                                                     constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]],
+                                                     constant SphericalHarmonicsDebugUniforms & shDebug [[ buffer(BufferIndexSphericalHarmonicsDebug) ]]) {
     FragmentStore out;
 
     (void)splatSHArray;
@@ -131,13 +132,23 @@ fragment FragmentStore multiStageSplatFragmentShader(FragmentIn in [[stage_in]],
 
     float3 diffuseSH = in.diffuseSH;
     float3 specularSH = in.specularSH;
+    float diffuseMagnitude = length(diffuseSH);
+    float specularMagnitude = length(specularSH);
 
     uint shMask = uniforms.useSHMask;
-    if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {
-        diffuseSH = float3(0);
-    }
-    if ((shMask & SphericalHarmonicsUsageSpecular) == 0) {
-        specularSH = float3(0);
+    bool maskDebugRequested = shDebug.enableMaskDebug != 0 && (DEBUG_VIEW_VALUE == 28 || DEBUG_VIEW_VALUE == 29);
+    if (maskDebugRequested) {
+        float packedMask = clamp(float(shMask & 0x3u) / 3.0f, 0.0f, 1.0f);
+        float3 debugVector = float3(diffuseMagnitude, specularMagnitude, packedMask);
+        diffuseSH = debugVector;
+        specularSH = debugVector;
+    } else {
+        if ((shMask & SphericalHarmonicsUsageDiffuse) == 0) {
+            diffuseSH = float3(0);
+        }
+        if ((shMask & SphericalHarmonicsUsageSpecular) == 0) {
+            specularSH = float3(0);
+        }
     }
 
     half4 albedoMetallic = half4(in.albedo * alpha, in.metallic * alpha);

--- a/MetalSplatter/Resources/ShaderCommon.h
+++ b/MetalSplatter/Resources/ShaderCommon.h
@@ -12,6 +12,7 @@ enum BufferIndex: int32_t
     BufferIndexUniforms = 0,
     BufferIndexSplat    = 1,
     BufferIndexSphericalHarmonics = 2,
+    BufferIndexSphericalHarmonicsDebug = 3,
 };
 
 enum TextureIndex: int32_t
@@ -50,6 +51,14 @@ typedef struct
     uint shCoefficientCount;
     uint useSHMask;
 } Uniforms;
+
+typedef struct
+{
+    uint shCoefficientCount;
+    uint useSHMask;
+    uint debugViewMode;
+    uint enableMaskDebug;
+} SphericalHarmonicsDebugUniforms;
 
 typedef struct
 {

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -275,6 +275,7 @@ public class SplatRenderer {
         case uniforms = 0
         case splat    = 1
         case sphericalHarmonics = 2
+        case sphericalHarmonicsDebug = 3
     }
 
     // Keep in sync with Shaders.metal : TextureIndex
@@ -319,6 +320,13 @@ public class SplatRenderer {
             default: break
             }
         }
+    }
+
+    struct SphericalHarmonicsDebugUniforms {
+        var shCoefficientCount: UInt32
+        var useSHMask: UInt32
+        var debugViewMode: UInt32
+        var enableMaskDebug: UInt32
     }
 
     struct PackedHalf3 {
@@ -479,6 +487,11 @@ public class SplatRenderer {
     var uniformBufferOffset = 0
     var uniformBufferIndex = 0
     var uniforms: UnsafeMutablePointer<UniformsArray>
+    var shDebugUniformBuffer: MTLBuffer
+    var shDebugUniformOffset = 0
+    var shDebugUniforms: UnsafeMutablePointer<SphericalHarmonicsDebugUniforms>
+
+    public var enableSphericalHarmonicsDiagnostics = false
 
     private var configuredSphericalHarmonicsCoefficientCount: UInt32?
     private var configuredSphericalHarmonicsUsageMask: UInt32?
@@ -544,6 +557,12 @@ public class SplatRenderer {
                                                        options: .storageModeShared)!
         self.dynamicUniformBuffers.label = "Uniform Buffers"
         self.uniforms = UnsafeMutableRawPointer(dynamicUniformBuffers.contents()).bindMemory(to: UniformsArray.self, capacity: 1)
+
+        let shDebugUniformBufferSize = MemoryLayout<SphericalHarmonicsDebugUniforms>.stride * maxSimultaneousRenders
+        self.shDebugUniformBuffer = device.makeBuffer(length: shDebugUniformBufferSize, options: .storageModeShared)!
+        self.shDebugUniformBuffer.label = "SH Debug Uniforms"
+        self.shDebugUniforms = UnsafeMutableRawPointer(shDebugUniformBuffer.contents())
+            .bindMemory(to: SphericalHarmonicsDebugUniforms.self, capacity: 1)
 
         self.splatBuffer = try MetalBuffer(device: device)
         self.splatSHBuffer = try MetalBuffer(device: device)
@@ -854,6 +873,7 @@ public class SplatRenderer {
 
     private var didLogEnvironmentFallbackThisFrame = false
     private var didLogBRDFFallbackThisFrame = false
+    private var didLogSphericalHarmonicsDebugThisFrame = false
     private var fallbackFrameStreak: UInt32 = 0
     private var didEscalateFallback = false
 
@@ -861,6 +881,7 @@ public class SplatRenderer {
         materialFallbackTelemetry = MaterialFallbackTelemetry()
         didLogEnvironmentFallbackThisFrame = false
         didLogBRDFFallbackThisFrame = false
+        didLogSphericalHarmonicsDebugThisFrame = false
     }
 
     private func updateGaussianImageRepresentationMetadata() {
@@ -888,6 +909,10 @@ public class SplatRenderer {
         uniformBufferIndex = (uniformBufferIndex + 1) % maxSimultaneousRenders
         uniformBufferOffset = UniformsArray.alignedSize * uniformBufferIndex
         uniforms = UnsafeMutableRawPointer(dynamicUniformBuffers.contents() + uniformBufferOffset).bindMemory(to: UniformsArray.self, capacity: 1)
+
+        shDebugUniformOffset = MemoryLayout<SphericalHarmonicsDebugUniforms>.stride * uniformBufferIndex
+        shDebugUniforms = UnsafeMutableRawPointer(shDebugUniformBuffer.contents() + shDebugUniformOffset)
+            .bindMemory(to: SphericalHarmonicsDebugUniforms.self, capacity: 1)
     }
 
     private func bindMaterialResources(to renderEncoder: MTLRenderCommandEncoder) {
@@ -1009,6 +1034,16 @@ public class SplatRenderer {
                                 indexedSplatCount: UInt32) {
         let shCoefficientCount = effectiveSphericalHarmonicsCoefficientCount()
         let shMask = effectiveSphericalHarmonicsUsageMask()
+
+        if !didLogSphericalHarmonicsDebugThisFrame {
+            didLogSphericalHarmonicsDebugThisFrame = true
+            Self.log.debug("[SH] coefficients=\(shCoefficientCount) useSHMask=0x\(String(shMask, radix: 16)) diagnostics=\(enableSphericalHarmonicsDiagnostics)")
+        }
+
+        shDebugUniforms.pointee = SphericalHarmonicsDebugUniforms(shCoefficientCount: shCoefficientCount,
+                                                                  useSHMask: shMask,
+                                                                  debugViewMode: UInt32(debugViewMode.rawValue),
+                                                                  enableMaskDebug: enableSphericalHarmonicsDiagnostics ? 1 : 0)
         for (i, viewport) in viewports.enumerated() where i <= maxViewCount {
             let cameraPosition = Self.cameraWorldPosition(forViewMatrix: viewport.viewMatrix)
             let uniforms = Uniforms(projectionMatrix: viewport.projectionMatrix,
@@ -1168,8 +1203,10 @@ public class SplatRenderer {
         renderEncoder.setVertexBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
         renderEncoder.setVertexBuffer(splatBuffer.buffer, offset: 0, index: BufferIndex.splat.rawValue)
         renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+        renderEncoder.setVertexBuffer(shDebugUniformBuffer, offset: shDebugUniformOffset, index: BufferIndex.sphericalHarmonicsDebug.rawValue)
         renderEncoder.setFragmentBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
         renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+        renderEncoder.setFragmentBuffer(shDebugUniformBuffer, offset: shDebugUniformOffset, index: BufferIndex.sphericalHarmonicsDebug.rawValue)
 
         renderEncoder.drawIndexedPrimitives(type: .triangle,
                                             indexCount: indexCount,
@@ -1193,6 +1230,8 @@ public class SplatRenderer {
             renderEncoder.setFragmentBuffer(dynamicUniformBuffers, offset: uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
             renderEncoder.setVertexBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
             renderEncoder.setFragmentBuffer(splatSHBuffer.buffer, offset: 0, index: BufferIndex.sphericalHarmonics.rawValue)
+            renderEncoder.setVertexBuffer(shDebugUniformBuffer, offset: shDebugUniformOffset, index: BufferIndex.sphericalHarmonicsDebug.rawValue)
+            renderEncoder.setFragmentBuffer(shDebugUniformBuffer, offset: shDebugUniformOffset, index: BufferIndex.sphericalHarmonicsDebug.rawValue)
             renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
             renderEncoder.popDebugGroup()
         } else {


### PR DESCRIPTION
## Summary
- add a GPU-visible spherical harmonics debug uniform block and per-frame logging of coefficient count and mask
- expose the debug buffer to render and postprocess passes so diagnostics can accompany the spherical harmonics debug views
- add a temporary mask-debug path in the multi-stage fragment shader that visualizes pre-mask SH magnitudes and mask bits for views 28/29

## Testing
- swift test *(fails: missing Metal/os modules in the Linux container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5360bf5c8321bc200628e6c8a462)