### PR TITLE
Add control for hand interactions in visionOS

### DIFF
--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -120,6 +120,11 @@ struct ContentView: View {
             if case .gaussianSplat = rendererSettings.activeModel {
                 switch rendererSettings.calibrationMode {
                 case .idle:
+                    Toggle("Hand Interactions", isOn: $rendererSettings.handInteractionEnabled)
+                        .padding(.horizontal)
+                        .toggleStyle(.switch)
+                        .disabled(!immersiveSpaceIsShown)
+
                     HStack(spacing: 16) {
                         Button("Calibrate") {
                             rendererSettings.calibrationMode = .running
@@ -136,6 +141,11 @@ struct ContentView: View {
                     }
                     .padding(.bottom)
                 case .running:
+                    Toggle("Hand Interactions", isOn: $rendererSettings.handInteractionEnabled)
+                        .padding(.horizontal)
+                        .toggleStyle(.switch)
+                        .disabled(!immersiveSpaceIsShown)
+
                     HStack(spacing: 16) {
                         Button("Confirm Calibration") {
                             rendererSettings.calibrationCommands.send(.confirm)

--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -16,10 +16,12 @@ final class RendererSettings: ObservableObject {
     }
 
     @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo
+    @Published var handInteractionEnabled: Bool = true
     @Published var activeModel: ModelIdentifier? {
         didSet {
             if oldValue != activeModel {
                 calibrationMode = .idle
+                handInteractionEnabled = true
             }
         }
     }

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -87,6 +87,9 @@ class VisionSceneRenderer {
 
     private var lastRotationUpdateTimestamp: Date? = nil
     private var interactionState = ModelInteractionState()
+    private var handInteractionEnabledStorage = true
+    private var shouldResetInteractions = false
+    private let interactionSettingsLock = NSLock()
 
     let arSession: ARKitSession
     let worldTracking: WorldTrackingProvider
@@ -403,6 +406,24 @@ class VisionSceneRenderer {
         return true
     }
 
+    private func setHandInteractionEnabled(_ enabled: Bool) {
+        interactionSettingsLock.lock()
+        handInteractionEnabledStorage = enabled
+        if !enabled {
+            shouldResetInteractions = true
+        }
+        interactionSettingsLock.unlock()
+    }
+
+    private func interactionControlState() -> (enabled: Bool, resetRequested: Bool) {
+        interactionSettingsLock.lock()
+        let enabled = handInteractionEnabledStorage
+        let reset = shouldResetInteractions
+        shouldResetInteractions = false
+        interactionSettingsLock.unlock()
+        return (enabled, reset)
+    }
+
     private func updateInteractionState() {
         let now = Date()
         defer { lastRotationUpdateTimestamp = now }
@@ -610,8 +631,15 @@ class VisionSceneRenderer {
             semaphore.signal()
         }
 
+        let interactionControl = interactionControlState()
+        if interactionControl.resetRequested {
+            resetToIdle()
+        }
+
         processCalibrationCommandsIfNeeded()
-        updateInteractionState()
+        if interactionControl.enabled {
+            updateInteractionState()
+        }
         updateEnvironmentProbeIfNeeded()
         applyEnvironmentResourcesIfNeeded()
 
@@ -679,9 +707,16 @@ class VisionSceneRenderer {
         debugViewMode = settings.debugViewMode
         rendererSettingsCancellables.removeAll()
 
+        setHandInteractionEnabled(settings.handInteractionEnabled)
         settings.$debugViewMode
             .sink { [weak self] mode in
                 self?.debugViewMode = mode
+            }
+            .store(in: &rendererSettingsCancellables)
+
+        settings.$handInteractionEnabled
+            .sink { [weak self] isEnabled in
+                self?.setHandInteractionEnabled(isEnabled)
             }
             .store(in: &rendererSettingsCancellables)
 


### PR DESCRIPTION
## Summary
- add a hand interaction enable flag that resets when the active model changes
- expose a visionOS toggle to control hand interactions
- subscribe the renderer to the toggle and skip gesture updates when interactions are disabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694216ea68988321b91d4cb764c825b6)