### PR TITLE
Persist hand interaction toggle

### DIFF
--- a/SampleApp/Scene/RendererSettings.swift
+++ b/SampleApp/Scene/RendererSettings.swift
@@ -16,16 +16,30 @@ final class RendererSettings: ObservableObject {
     }
 
     @Published var debugViewMode: SplatRenderer.DebugViewMode = .albedo
-    @Published var handInteractionEnabled: Bool = true
+    @Published var handInteractionEnabled: Bool {
+        didSet {
+            storeHandInteractionEnabled()
+        }
+    }
     @Published var activeModel: ModelIdentifier? {
         didSet {
             if oldValue != activeModel {
                 calibrationMode = .idle
-                handInteractionEnabled = true
             }
         }
     }
     @Published var calibrationMode: CalibrationMode = .idle
+
+    private let handInteractionEnabledKey = "handInteractionEnabled"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if defaults.object(forKey: handInteractionEnabledKey) == nil {
+            defaults.set(true, forKey: handInteractionEnabledKey)
+        }
+        handInteractionEnabled = defaults.bool(forKey: handInteractionEnabledKey)
+    }
 
     let calibrationCommands = PassthroughSubject<CalibrationCommand, Never>()
     let primaryDebugModes: [SplatRenderer.DebugViewMode] = [
@@ -38,6 +52,10 @@ final class RendererSettings: ObservableObject {
         .depth,
         .coverage
     ]
+
+    private func storeHandInteractionEnabled() {
+        defaults.set(handInteractionEnabled, forKey: handInteractionEnabledKey)
+    }
 }
 
 extension SplatRenderer.DebugViewMode {


### PR DESCRIPTION
## Summary
- keep the hand interaction toggle global instead of resetting when switching models
- persist hand interaction preference to user defaults so it survives app restarts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694245bfe61c83219289a5c9b3e005c2)